### PR TITLE
feat: add ability to upload files as release assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,18 +50,26 @@ jobs:
 ```
 
 ## Uploading assets
-Currently, it is only possible to transfer build artifacts, uploaded in your current workflow, to your GitHub Release.
-
-This can be done by providing the `artifacts` input parameter, for ex.:
+ReleaseMe allows you to upload assets from both build artifacts (`artifacts:`) and local files (`files:`).
 
 ```yaml
+# Create an example file
+- run: echo "Example" > output.txt
+
+# Upload the output file as a build artifact
+- uses: actions/upload-artifact@v3
+  with:
+    name: output-as-artifact
+    path: output.txt
+
+# Create a GitHub Release with both the direct output file
+# and build artifact as asset
 - name: Run ReleaseMe
   uses: dev-build-deploy/release-me@v0
   with:
     token: ${{ github.token }}
-    artifacts: |
-      artifact Foo
-      artifact Bar
+    artifacts: output-as-artifact
+    files: output.txt
 ```
 
 ## GitHub Release Configuration
@@ -107,6 +115,7 @@ changelog:
 | `prefix` | NO | Prefix for the Semantic Version, MUST be one of `[A-Za-z0-9-.]` |
 | `config`  | NO | Path to the Release configuration, defaults to `.github/release.yml` | 
 | `artifacts` | NO | Multiline list of artifact names, uploaded as part of the current workflow run, to upload as a GitHub Release asset |
+| `files` | NO | Multiline list of files (paths) to upload as a GitHub Release asset |
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,10 @@ inputs:
   artifacts:
     description: 'Artifact names to include in the GitHub Release'
     required: false
+  
+  files:
+    description: 'Files to include in the GitHub Release'
+    required: false
 
 outputs:
   created:

--- a/lib/index.js
+++ b/lib/index.js
@@ -17548,25 +17548,41 @@ const version_it_1 = __nccwpck_require__(4209);
 const commit_it_1 = __nccwpck_require__(9403);
 const changelog_1 = __nccwpck_require__(8598);
 /**
+ * Downloads the list of artifacts
+ * @param artifacts List of artifacts to download
+ * @returns List of filepaths towards the downloaded artifacts
+ */
+function downloadArtifacts(artifacts) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const client = artifact.create();
+        const filepaths = [];
+        for (const artifact of artifacts) {
+            core.startGroup(`📡 Downloading artifact: ${artifact}`);
+            const dirname = `release-me-asset-${artifact.replace(/[^a-z0-9]/gi, "_").toLowerCase()}`;
+            const resp = yield client.downloadArtifact(artifact, dirname, { createArtifactFolder: false });
+            console.log(resp);
+            for (const file of fs.readdirSync(dirname)) {
+                filepaths.push({ name: path.join(dirname, file), label: artifact });
+            }
+            core.endGroup();
+        }
+        return filepaths;
+    });
+}
+/**
  * Uploads the list of artifacts to the GitHub Release
  * @param assets List of artifacts to upload
  */
-function uploadArtifacts(id, artifacts) {
+function uploadAssets(id, assets) {
     return __awaiter(this, void 0, void 0, function* () {
         const octokit = github.getOctokit(core.getInput("token"));
-        const client = artifact.create();
-        for (const artifact of artifacts) {
-            core.startGroup(`📡 Uploading artifact: ${artifact}`);
-            // Unique directory name for the artifact
-            const dirname = `release-me-asset-${artifact.replace(/[^a-z0-9]/gi, "_").toLowerCase()}`;
-            // Download artifact from GitHub
-            yield client.downloadArtifact(artifact, dirname, { createArtifactFolder: false });
-            // Upload files associated with the artifact to the GitHub Release
-            for (const file of fs.readdirSync(dirname)) {
-                const data = fs.readFileSync(path.join(dirname, file), { encoding: "utf8" });
-                yield octokit.rest.repos.uploadReleaseAsset(Object.assign(Object.assign({}, github.context.repo), { release_id: id, name: file, label: artifact, data: data }));
+        for (const asset of assets) {
+            core.info(`🔗 Uploading ${asset.label ? asset.label : asset.name}...`);
+            if (!fs.existsSync(asset.name)) {
+                throw new Error(`File ${asset.name} does not exist!`);
             }
-            core.endGroup();
+            const data = fs.readFileSync(asset.name, { encoding: "utf8" });
+            yield octokit.rest.repos.uploadReleaseAsset(Object.assign(Object.assign({}, github.context.repo), { release_id: id, name: asset.name, label: asset.label ? asset.label : asset.name, data: data }));
         }
     });
 }
@@ -17689,7 +17705,7 @@ function isDefaultBranch() {
  * @internal
  */
 function run() {
-    var _a, _b;
+    var _a, _b, _c;
     return __awaiter(this, void 0, void 0, function* () {
         try {
             core.info("📄 ReleaseMe - GitHub Release Management");
@@ -17720,7 +17736,11 @@ function run() {
             const newVersion = new version_it_1.SemVer(latestRelease.tag_name, prefix).increment(increment);
             core.info(`📦 Creating GitHub Release...`);
             const release = yield createRelease(newVersion, commits);
-            yield uploadArtifacts(release.id, (_b = core.getMultilineInput("artifacts")) !== null && _b !== void 0 ? _b : []);
+            const files = [
+                ...(yield downloadArtifacts((_b = core.getMultilineInput("artifacts")) !== null && _b !== void 0 ? _b : [])),
+                ...((_c = core.getMultilineInput("files")) !== null && _c !== void 0 ? _c : []).map(f => ({ name: f, label: f })),
+            ];
+            yield uploadAssets(release.id, files);
             core.setOutput("release", JSON.stringify(release));
             core.setOutput("created", true);
             core.info(`✅ Created GitHub Release ${newVersion}!`);


### PR DESCRIPTION
Introduces the `files:` input parameter (multiline) to allow users to specify certain (local) files to upload to the GitHub Release