### PR TITLE
fix: support conventional commits with GitHub issue reference (#24)

### DIFF
--- a/lib/assets/index.js
+++ b/lib/assets/index.js
@@ -3618,6 +3618,19 @@ class HttpClientResponse {
             }));
         });
     }
+    readBodyBuffer() {
+        return __awaiter(this, void 0, void 0, function* () {
+            return new Promise((resolve) => __awaiter(this, void 0, void 0, function* () {
+                const chunks = [];
+                this.message.on('data', (chunk) => {
+                    chunks.push(chunk);
+                });
+                this.message.on('end', () => {
+                    resolve(Buffer.concat(chunks));
+                });
+            }));
+        });
+    }
 }
 exports.HttpClientResponse = HttpClientResponse;
 function isHttps(requestUrl) {
@@ -4122,7 +4135,13 @@ function getProxyUrl(reqUrl) {
         }
     })();
     if (proxyVar) {
-        return new URL(proxyVar);
+        try {
+            return new URL(proxyVar);
+        }
+        catch (_a) {
+            if (!proxyVar.startsWith('http://') && !proxyVar.startsWith('https://'))
+                return new URL(`http://${proxyVar}`);
+        }
     }
     else {
         return undefined;

--- a/lib/get/index.js
+++ b/lib/get/index.js
@@ -1427,6 +1427,19 @@ class HttpClientResponse {
             }));
         });
     }
+    readBodyBuffer() {
+        return __awaiter(this, void 0, void 0, function* () {
+            return new Promise((resolve) => __awaiter(this, void 0, void 0, function* () {
+                const chunks = [];
+                this.message.on('data', (chunk) => {
+                    chunks.push(chunk);
+                });
+                this.message.on('end', () => {
+                    resolve(Buffer.concat(chunks));
+                });
+            }));
+        });
+    }
 }
 exports.HttpClientResponse = HttpClientResponse;
 function isHttps(requestUrl) {
@@ -1931,7 +1944,13 @@ function getProxyUrl(reqUrl) {
         }
     })();
     if (proxyVar) {
-        return new URL(proxyVar);
+        try {
+            return new URL(proxyVar);
+        }
+        catch (_a) {
+            if (!proxyVar.startsWith('http://') && !proxyVar.startsWith('https://'))
+                return new URL(`http://${proxyVar}`);
+        }
     }
     else {
         return undefined;
@@ -2246,17 +2265,17 @@ exports.isConventionalCommit = isConventionalCommit;
  */
 function getConventionalCommit(commit, options) {
     var _a, _b, _c, _d, _e, _f;
-    const ConventionalCommitRegex = new RegExp(/^(?<type>[^(!:]*)(?<scope>\(.*\))?(?<breaking>\s*!)?(?<separator>\s*:)?(?<spacing>\s*)(?<subject>.*)?$/);
+    const ConventionalCommitRegex = new RegExp(/^(?<type>[^(!:]*)(?<scope>\([^)]*\))?(?<breaking>\s*!)?(?<separator>\s*:)?(?<spacing>\s*)(?<subject>.*)?$/);
     const match = ConventionalCommitRegex.exec(commit.subject);
     let conventionalCommit = {
         commit: commit,
-        type: { index: 0, value: (_a = match === null || match === void 0 ? void 0 : match.groups) === null || _a === void 0 ? void 0 : _a.type },
-        scope: { index: 0, value: (_b = match === null || match === void 0 ? void 0 : match.groups) === null || _b === void 0 ? void 0 : _b.scope },
-        breaking: { index: 0, value: (_c = match === null || match === void 0 ? void 0 : match.groups) === null || _c === void 0 ? void 0 : _c.breaking },
-        seperator: { index: 0, value: (_d = match === null || match === void 0 ? void 0 : match.groups) === null || _d === void 0 ? void 0 : _d.separator },
-        spacing: { index: 0, value: (_e = match === null || match === void 0 ? void 0 : match.groups) === null || _e === void 0 ? void 0 : _e.spacing },
-        description: { index: 0, value: (_f = match === null || match === void 0 ? void 0 : match.groups) === null || _f === void 0 ? void 0 : _f.subject },
-        body: { index: 0, value: commit.body },
+        type: { index: 1, value: (_a = match === null || match === void 0 ? void 0 : match.groups) === null || _a === void 0 ? void 0 : _a.type },
+        scope: { index: 1, value: (_b = match === null || match === void 0 ? void 0 : match.groups) === null || _b === void 0 ? void 0 : _b.scope },
+        breaking: { index: 1, value: (_c = match === null || match === void 0 ? void 0 : match.groups) === null || _c === void 0 ? void 0 : _c.breaking },
+        seperator: { index: 1, value: (_d = match === null || match === void 0 ? void 0 : match.groups) === null || _d === void 0 ? void 0 : _d.separator },
+        spacing: { index: 1, value: (_e = match === null || match === void 0 ? void 0 : match.groups) === null || _e === void 0 ? void 0 : _e.spacing },
+        description: { index: 1, value: (_f = match === null || match === void 0 ? void 0 : match.groups) === null || _f === void 0 ? void 0 : _f.subject },
+        body: { index: 1, value: commit.body },
     };
     function intializeIndices(commit) {
         var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k;
@@ -2560,7 +2579,7 @@ function createError(commit, description, highlight, type) {
         .id(commit.commit.hash)
         .error(highlightString(description, highlight))
         .lineNumber(1)
-        .caret(data.index, ((_a = data.value) === null || _a === void 0 ? void 0 : _a.length) || 0)
+        .caret(data.index, ((_a = data.value) === null || _a === void 0 ? void 0 : _a.length) || 1)
         .context(commit.commit.body !== undefined && commit.commit.body.split("\n").length >= 1
         ? [commit.commit.subject, "", ...commit.commit.body.split("\n")]
         : [commit.commit.subject], 1);
@@ -2708,9 +2727,9 @@ exports.commitRules = [new CC01(), new CC04(), new CC05(), new EC01(), new EC02(
 "use strict";
 
 /*
-SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
-SPDX-License-Identifier: MIT
-*/
+ * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
+ */
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
@@ -2730,7 +2749,7 @@ const assert_1 = __importDefault(__nccwpck_require__(9491));
  *    10 |     - uses: actions/setup-node@v2
  *    11 |       with:
  *
- * The format is loosely baed onthe LLVM "Expressive Diagnostics" specification, with
+ * The format is loosely based on the LLVM "Expressive Diagnostics" specification, with
  * additional support for context.
  *
  * @class ExpressiveMessage
@@ -2743,7 +2762,7 @@ const assert_1 = __importDefault(__nccwpck_require__(9491));
  * @function context Context around the error
  * @function toString Returns the formatted message
  *
- * @see https://clang.llvm.org/docs/ClangFormatStyleOptions.html#expressive-diagnostic-formatting
+ * @see https://clang.llvm.org/diagnostics.html
  */
 class ExpressiveMessage extends Error {
     constructor(message) {
@@ -2752,8 +2771,8 @@ class ExpressiveMessage extends Error {
         this._id = undefined;
         this._type = "note";
         this._message = undefined;
-        this._lineNumber = 0;
-        this._caret = { index: 0, length: 0 };
+        this._lineNumber = 1;
+        this._caret = { index: 1, length: 1 };
         if (message) {
             this.id(message.id);
             switch (message.type) {
@@ -2763,14 +2782,15 @@ class ExpressiveMessage extends Error {
                 case "warning":
                     this.warning(message.message);
                     break;
-                case "note" || 0:
+                case "note":
+                case undefined:
                     this.note(message.message);
                     break;
             }
-            this.lineNumber((_a = message.lineNumber) !== null && _a !== void 0 ? _a : 0);
+            this.lineNumber((_a = message.lineNumber) !== null && _a !== void 0 ? _a : 1);
             if (message.context !== undefined)
                 this.context(message.context.lines, message.context.index);
-            this.caret((_c = (_b = message.caret) === null || _b === void 0 ? void 0 : _b.index) !== null && _c !== void 0 ? _c : 0, (_e = (_d = message.caret) === null || _d === void 0 ? void 0 : _d.length) !== null && _e !== void 0 ? _e : 0);
+            this.caret((_c = (_b = message.caret) === null || _b === void 0 ? void 0 : _b.index) !== null && _c !== void 0 ? _c : 1, (_e = (_d = message.caret) === null || _d === void 0 ? void 0 : _d.length) !== null && _e !== void 0 ? _e : 1);
         }
     }
     /**
@@ -2822,8 +2842,8 @@ class ExpressiveMessage extends Error {
      * @returns this
      */
     lineNumber(lineNumber) {
-        if (lineNumber < 0)
-            throw new RangeError("Line number must be greater or equal to 0.");
+        if (lineNumber <= 0)
+            throw new RangeError("Line number must be greater than 0.");
         this._lineNumber = lineNumber;
         this.update();
         return this;
@@ -2835,13 +2855,13 @@ class ExpressiveMessage extends Error {
      * @returns this
      */
     caret(columnNumber, length) {
-        if (columnNumber < 0)
-            throw new RangeError("Column number must be greater or equal to 0.");
-        if (length !== undefined && length < 0)
-            throw new RangeError("Caret length must be greater or equal to 0.");
+        if (columnNumber <= 0)
+            throw new RangeError("Column number must be greater than 0.");
+        if (length !== undefined && length <= 0)
+            throw new RangeError("Caret length must be greater than 0.");
         this._caret = {
             index: columnNumber,
-            length: length !== null && length !== void 0 ? length : 0,
+            length: length !== null && length !== void 0 ? length : 1,
         };
         this.update();
         return this;
@@ -2863,8 +2883,8 @@ class ExpressiveMessage extends Error {
      * @returns this
      */
     context(lines, start) {
-        if (start < 0)
-            throw new RangeError("Initial line number must be greater or equal to 0.");
+        if (start < 1)
+            throw new RangeError("Initial line number must be greater than 0.");
         if (typeof lines === "string")
             lines = lines.split("\n");
         this._context = { index: start, lines: lines.length > 0 ? lines : [] };
@@ -2876,8 +2896,9 @@ class ExpressiveMessage extends Error {
      */
     update() {
         const GREEN = "\x1b[0;32m";
+        const LIGHT_PURPLE = "\x1b[1;35m";
         const RED = "\x1b[1;31m";
-        this.message = `\x1b[1m${this._id}:${this._lineNumber}:${this._caret.index}: ${this._type === "error" ? RED : GREEN}${this._type}:\x1b[0m\x1b[1m ${this._message}\x1b[0m`;
+        this.message = `\x1b[1m${this._id}:${this._lineNumber}:${this._caret.index}: ${this._type === "error" ? RED : this._type === "warning" ? LIGHT_PURPLE : GREEN}${this._type}:\x1b[0m\x1b[1m ${this._message}\x1b[0m`;
         if (this._context === undefined)
             return;
         this.message += "\n\n";
@@ -2890,9 +2911,9 @@ class ExpressiveMessage extends Error {
                 formattedLine = `\u001b[38;5;245m${formattedLine}\u001b[0m`;
             this.message += formattedLine;
             if (this._lineNumber === lineNumber) {
-                this.message += `  ${" ".repeat(maxWidth)} | ${" ".repeat(this._caret.index)}\u001b[32;1m^${"-".repeat(this._caret.length > 0 ? this._caret.length - 1 : 0)}\u001b[0m\n`;
+                this.message += `  ${" ".repeat(maxWidth)} | ${" ".repeat(this._caret.index - 1)}\u001b[32;1m^${"-".repeat(this._caret.length > 0 ? this._caret.length - 1 : 0)}\u001b[0m\n`;
                 if (this._hint !== undefined) {
-                    this.message += `  ${" ".repeat(maxWidth)} | ${" ".repeat(this._caret.index)}${this._hint}\n`;
+                    this.message += `  ${" ".repeat(maxWidth)} | ${" ".repeat(this._caret.index - 1)}${this._hint}\n`;
                 }
             }
         });
@@ -2914,6 +2935,24 @@ class ExpressiveMessage extends Error {
             throw new Error("Cannot specify a hint without a caret.");
         return this.message;
     }
+    /**
+     * Returns the Expressive Diagnostics message as a JSON object.
+     */
+    toJSON() {
+        if (this._id === undefined)
+            throw new Error("No identifier (i.e. filename) has been provided.");
+        if (this._message === undefined)
+            throw new Error("No message has been specified.");
+        return {
+            id: this._id,
+            type: this._type,
+            message: this._message,
+            lineNumber: this._lineNumber,
+            caret: this._caret,
+            hint: this._hint,
+            context: this._context,
+        };
+    }
 }
 exports.ExpressiveMessage = ExpressiveMessage;
 
@@ -2926,13 +2965,568 @@ exports.ExpressiveMessage = ExpressiveMessage;
 "use strict";
 
 /*
-SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
-SPDX-License-Identifier: MIT
-*/
+ * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
+ */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.ExpressiveMessage = void 0;
+exports.extractFromSarif = exports.extractFromFile = exports.ExpressiveMessage = void 0;
 var diagnostics_1 = __nccwpck_require__(275);
 Object.defineProperty(exports, "ExpressiveMessage", ({ enumerable: true, get: function () { return diagnostics_1.ExpressiveMessage; } }));
+var parser_1 = __nccwpck_require__(9753);
+Object.defineProperty(exports, "extractFromFile", ({ enumerable: true, get: function () { return parser_1.extractFromFile; } }));
+Object.defineProperty(exports, "extractFromSarif", ({ enumerable: true, get: function () { return parser_1.extractFromSarif; } }));
+
+
+/***/ }),
+
+/***/ 9753:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+/*
+ * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.extractFromFile = exports.extractFromSarif = void 0;
+const readline_1 = __importDefault(__nccwpck_require__(4521));
+const fs_1 = __importDefault(__nccwpck_require__(7147));
+const diagnostics_1 = __nccwpck_require__(275);
+const sarif = __importStar(__nccwpck_require__(1496));
+const LLVM_EXPRESSIVE_DIAGNOSTICS_REGEX = new RegExp("(?<file>[\\w,\\s-.]+):(?<lineNumber>[0-9]+):(?<columnNumber>[0-9]+): (?<messageType>(error|warning|note)): (?<message>(.*))");
+/**
+ * Extracts Expressive Diagnostic messages from SARIF.
+ *
+ * NOTE: currently we only support:
+ *   - plain text files
+ *   - the results of the last run
+ *
+ * @param sarif The SARIF to extract messages from.
+ * @param run Index of run, defaults to the last run.
+ *
+ * @returns Async Generator of Expressive Messages.
+ */
+function* extractFromSarif(sarif, run = undefined) {
+    var _a, _b, _c, _d, _e, _f, _g, _h;
+    const sarifObj = sarif.properties();
+    if (run === undefined) {
+        run = sarifObj.runs.length - 1;
+    }
+    const results = (_a = sarifObj.runs[run].results) !== null && _a !== void 0 ? _a : [];
+    for (const result of results) {
+        for (const location of (_b = result.locations) !== null && _b !== void 0 ? _b : []) {
+            if (result.message.text === undefined || location.physicalLocation === undefined) {
+                continue;
+            }
+            const msg = new diagnostics_1.ExpressiveMessage({
+                id: (_d = (_c = location.physicalLocation.artifactLocation) === null || _c === void 0 ? void 0 : _c.uri) !== null && _d !== void 0 ? _d : "",
+                message: result.message.text,
+                type: ((_e = result.level) !== null && _e !== void 0 ? _e : "warning"),
+            });
+            if (location.physicalLocation.region) {
+                const region = location.physicalLocation.region;
+                const line = (_f = region.startLine) !== null && _f !== void 0 ? _f : 1;
+                const column = (_g = region.startColumn) !== null && _g !== void 0 ? _g : 1;
+                const length = region.endColumn && column ? region.endColumn - column : 1;
+                const snippet = (_h = region.snippet) === null || _h === void 0 ? void 0 : _h.text;
+                msg.lineNumber(line).caret(column !== null && column !== void 0 ? column : 1, length !== null && length !== void 0 ? length : 1);
+                if (snippet !== undefined) {
+                    msg.context(snippet, line);
+                }
+            }
+            yield msg;
+        }
+    }
+}
+exports.extractFromSarif = extractFromSarif;
+/**
+ * Extracts Expressive Diagnostic messages from a raw file.
+ * This can be used to extract messages from compiler output
+ *
+ * @param filePath Path to file to extract messages from.
+ */
+async function* extractRaw(filePath) {
+    let currentMessage = undefined;
+    let matchIndex = 0;
+    const lineReader = readline_1.default.createInterface({
+        input: fs_1.default.createReadStream(filePath),
+        crlfDelay: Infinity,
+    });
+    for await (const line of lineReader) {
+        const match = LLVM_EXPRESSIVE_DIAGNOSTICS_REGEX.exec(line);
+        if (match && match.groups) {
+            currentMessage = new diagnostics_1.ExpressiveMessage({
+                id: match.groups.file,
+                message: match.groups.message,
+                type: match.groups.messageType,
+                lineNumber: parseInt(match.groups.lineNumber),
+                caret: { index: parseInt(match.groups.columnNumber), length: 1 },
+            });
+            matchIndex = line.length - line.trimStart().length;
+        }
+        else if (currentMessage) {
+            const lineNumber = currentMessage.toJSON().lineNumber;
+            if (lineNumber !== undefined) {
+                currentMessage = currentMessage.context(line.substring(matchIndex), lineNumber);
+            }
+            yield currentMessage;
+            currentMessage = undefined;
+        }
+    }
+    if (currentMessage) {
+        yield currentMessage;
+    }
+}
+/**
+ * Extracts Expressive Diagnostic messages from a file.
+ * This can be used to extract messages from compile output
+ *
+ * @param filePath Path to file to extract messages from.
+ * @returns Async Generator of Expressive Messages.
+ *
+ * @see https://clang.llvm.org/diagnostics.html
+ */
+async function* extractFromFile(filePath) {
+    if (filePath.endsWith(".sarif") || filePath.endsWith(".json.sarif")) {
+        const sarifData = sarif.Log.fromFile(filePath);
+        for (const message of extractFromSarif(sarifData)) {
+            yield message;
+        }
+        return;
+    }
+    for await (const message of extractRaw(filePath)) {
+        yield message;
+    }
+}
+exports.extractFromFile = extractFromFile;
+
+
+/***/ }),
+
+/***/ 1496:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+/**
+ * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.Rule = exports.Result = exports.Tool = exports.Run = exports.Log = void 0;
+var log_1 = __nccwpck_require__(3957);
+Object.defineProperty(exports, "Log", ({ enumerable: true, get: function () { return log_1.Log; } }));
+var run_1 = __nccwpck_require__(3205);
+Object.defineProperty(exports, "Run", ({ enumerable: true, get: function () { return run_1.Run; } }));
+var tool_1 = __nccwpck_require__(3431);
+Object.defineProperty(exports, "Tool", ({ enumerable: true, get: function () { return tool_1.Tool; } }));
+var result_1 = __nccwpck_require__(6159);
+Object.defineProperty(exports, "Result", ({ enumerable: true, get: function () { return result_1.Result; } }));
+var rule_1 = __nccwpck_require__(2917);
+Object.defineProperty(exports, "Rule", ({ enumerable: true, get: function () { return rule_1.Rule; } }));
+
+
+/***/ }),
+
+/***/ 6027:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+/**
+ * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.ISarif = void 0;
+class ISarif {
+    constructor(data) {
+        this._data = data;
+    }
+    /** Getter for a property by name */
+    get(property) {
+        const properties = Object.keys(this._data);
+        if (properties.includes(property)) {
+            return this._data[property];
+        }
+        throw new Error(`Property '${property}' does not exist.`);
+    }
+    /** Returns all SARIF properties */
+    properties() {
+        return this._data;
+    }
+}
+exports.ISarif = ISarif;
+
+
+/***/ }),
+
+/***/ 3957:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+/**
+ * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.Log = void 0;
+const fs = __importStar(__nccwpck_require__(7147));
+const run_1 = __nccwpck_require__(3205);
+const interfaces_1 = __nccwpck_require__(6027);
+const tool_1 = __nccwpck_require__(3431);
+const result_1 = __nccwpck_require__(6159);
+/** Static Analysis Results Format (SARIF) Version 2.1.0 */
+class Log extends interfaces_1.ISarif {
+    constructor() {
+        super({
+            $schema: "http://json.schemastore.org/sarif-2.1.0.json",
+            version: "2.1.0",
+            runs: []
+        });
+    }
+    /**
+     * Adds a single run to the SARIF log
+     */
+    addRun(run) {
+        this._data.runs.push(run.properties());
+        return this;
+    }
+    /**
+     * Creates a new SARIF log object from a file
+     *
+     * @param filePath The path to the SARIF file
+     * @returns A new SARIF log object
+     */
+    static fromFile(filePath) {
+        const data = JSON.parse(fs.readFileSync(filePath, { encoding: "utf-8" }));
+        const log = new Log();
+        if (Object.keys(data).includes("runs") && Array.isArray(data.runs)) {
+            for (const sarifRun of data.runs) {
+                const tool = new tool_1.Tool(sarifRun.tool.driver.name, sarifRun.tool.driver);
+                const run = new run_1.Run(tool);
+                if (Object.keys(sarifRun).includes("results") && Array.isArray(sarifRun.results)) {
+                    for (const result of sarifRun.results) {
+                        const res = new result_1.Result(result.message, result);
+                        run.addResult(res);
+                    }
+                }
+                log.addRun(run);
+            }
+        }
+        return log;
+    }
+}
+exports.Log = Log;
+
+
+/***/ }),
+
+/***/ 6159:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+/**
+ * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.Result = void 0;
+const interfaces_1 = __nccwpck_require__(6027);
+/** A result produced by an analysis tool. */
+class Result extends interfaces_1.ISarif {
+    /** A result produced by an analysis tool. */
+    constructor(message, options = {}) {
+        const msg = typeof message === "string" ? { text: message } : message;
+        super({
+            message: msg,
+            ...options
+        });
+    }
+    /** The stable, unique identifier of the rule, if any, to which this result is relevant. */
+    ruleId(ruleId) {
+        this._data.ruleId = ruleId;
+        return this;
+    }
+    /** A value specifying the severity level of the result. */
+    level(level) {
+        this._data.level = level;
+        return this;
+    }
+    /** Encapsulates a message intended to be read by the end user. */
+    message(message) {
+        this._data.message = typeof message === "string" ? { text: message } : message;
+        return this;
+    }
+    /**
+     * Extends the set of locations where the result was detected. Specify only one location
+     * unless the problem indicated by the result can only be corrected by making a change
+     * at every specified location.
+     */
+    addLocation(location) {
+        var _a;
+        if (this._data.locations === undefined) {
+            this._data.locations = [];
+        }
+        this._data.locations.push(location);
+        this._data.occurrenceCount = ((_a = this._data.occurrenceCount) !== null && _a !== void 0 ? _a : 0) + 1;
+        return this;
+    }
+}
+exports.Result = Result;
+
+
+/***/ }),
+
+/***/ 2917:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+/**
+ * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.Rule = void 0;
+const interfaces_1 = __nccwpck_require__(6027);
+/** Metadata that describes a specific report produced by the tool, as part of the analysis it provides or its runtime reporting. */
+class Rule extends interfaces_1.ISarif {
+    /** Metadata that describes a specific report produced by the tool, as part of the analysis it provides or its runtime reporting. */
+    constructor(id, options = {}) {
+        const short = typeof options.shortDescription === "string" ? { text: options.shortDescription } : options.shortDescription;
+        const full = typeof options.fullDescription === "string" ? { text: options.fullDescription } : options.fullDescription;
+        if (short === undefined && full === undefined) {
+            super({ id: id });
+        }
+        else if (short !== undefined && full === undefined) {
+            super({
+                id: id,
+                shortDescription: short
+            });
+        }
+        else if (short === undefined && full !== undefined) {
+            super({
+                id: id,
+                fullDescription: full
+            });
+        }
+        else {
+            super({
+                id: id,
+                shortDescription: short,
+                fullDescription: full
+            });
+        }
+    }
+    /** A report identifier that is understandable to an end user. */
+    name(name) {
+        this._data.name = name;
+        return this;
+    }
+    /**
+     * A concise description of the report. Should be a single sentence that is understandable when visible
+     * space is limited to a single line of text.
+     */
+    shortDescription(shortDescription) {
+        this._data.shortDescription = typeof shortDescription === "string" ? { text: shortDescription } : shortDescription;
+        return this;
+    }
+    /**
+     * A description of the report. Should, as far as possible, provide details sufficient to enable resolution
+     * of any problem indicated by the result.
+     */
+    fullDescription(fullDescription) {
+        this._data.fullDescription = typeof fullDescription === "string" ? { text: fullDescription } : fullDescription;
+        return this;
+    }
+    /** A URI where the primary documentation for the report can be found. */
+    helpUri(helpUri) {
+        this._data.helpUri = helpUri;
+        return this;
+    }
+}
+exports.Rule = Rule;
+
+
+/***/ }),
+
+/***/ 3205:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+/**
+ * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.Run = void 0;
+const interfaces_1 = __nccwpck_require__(6027);
+/** Describes a single run of an analysis tool, and contains the reported output of that run. */
+class Run extends interfaces_1.ISarif {
+    /**
+     * Describes a single run of an analysis tool, and contains the reported output of that run.
+     * @param tool The tool or tool pipeline that generated the results in this run.
+     */
+    constructor(tool) {
+        super({
+            tool: tool.properties()
+        });
+    }
+    /**
+     * Information about the tool or tool pipeline that generated the results in this run. A run can only
+     * contain results produced by a single tool or tool pipeline. A run can aggregate results from multiple
+     * log files, as long as context around the tool run (tool command-line arguments and the like) is
+     * identical for all aggregated files.
+     */
+    tool(tool) {
+        this._data.tool = tool.properties();
+        return this;
+    }
+    /**
+     * Extends the set of results contained in an SARIF log. The results array can be omitted when a run
+     * is solely exporting rules metadata. It must be present (but may be empty) if a log file represents
+     * an actual scan.
+     */
+    addResult(result) {
+        var _a, _b, _c, _d;
+        if (this._data.results === undefined) {
+            this._data.results = [];
+        }
+        for (const item of this._data.results) {
+            if (item.message.text === result.properties().message.text) {
+                (_a = item.locations) === null || _a === void 0 ? void 0 : _a.push(...(_b = result.properties().locations) !== null && _b !== void 0 ? _b : []);
+                item.occurrenceCount = ((_c = item.occurrenceCount) !== null && _c !== void 0 ? _c : 1) + ((_d = result.properties().occurrenceCount) !== null && _d !== void 0 ? _d : 1);
+                return this;
+            }
+        }
+        this._data.results.push(result.properties());
+        return this;
+    }
+}
+exports.Run = Run;
+
+
+/***/ }),
+
+/***/ 3431:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+/**
+ * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.Tool = void 0;
+const interfaces_1 = __nccwpck_require__(6027);
+/** The analysis tool that was run. */
+class Tool extends interfaces_1.ISarif {
+    //private _data: sarif.Tool;
+    constructor(name, options = {}) {
+        super({
+            driver: {
+                name: name,
+                ...options
+            }
+        });
+    }
+    /** The name of the tool component. */
+    name(name) {
+        this._data.driver.name = name;
+        return this;
+    }
+    /** The organization or company that produced the tool component. */
+    organization(organization) {
+        this._data.driver.organization = organization;
+        return this;
+    }
+    /** The tool component version, in whatever format the component natively provides. */
+    version(version) {
+        this._data.driver.version = version;
+        return this;
+    }
+    /** The absolute URI at which information about this version of the tool component can be found. */
+    informationUri(informationUri) {
+        this._data.driver.informationUri = informationUri;
+        return this;
+    }
+    /** Extends the list of rules relevant to the analysis performed by the tool component. */
+    addRule(rule) {
+        if (this._data.driver.rules === undefined) {
+            this._data.driver.rules = [];
+        }
+        if (this._data.driver.rules.some(r => r.id === rule.get("id"))) {
+            this._data.driver.rules = this._data.driver.rules.filter(r => r.id !== rule.get("id"));
+        }
+        this._data.driver.rules.push(rule.properties());
+        return this;
+    }
+    /** Getter for a property by name */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    get(property) {
+        const properties = Object.keys(this._data.driver);
+        if (properties.includes(property)) {
+            return this._data.driver[property];
+        }
+        throw new Error(`Property '${property}' does not exist.`);
+    }
+}
+exports.Tool = Tool;
 
 
 /***/ }),
@@ -11707,6 +12301,14 @@ module.exports = require("path");
 
 "use strict";
 module.exports = require("punycode");
+
+/***/ }),
+
+/***/ 4521:
+/***/ ((module) => {
+
+"use strict";
+module.exports = require("readline");
 
 /***/ }),
 

--- a/lib/main/index.js
+++ b/lib/main/index.js
@@ -3618,6 +3618,19 @@ class HttpClientResponse {
             }));
         });
     }
+    readBodyBuffer() {
+        return __awaiter(this, void 0, void 0, function* () {
+            return new Promise((resolve) => __awaiter(this, void 0, void 0, function* () {
+                const chunks = [];
+                this.message.on('data', (chunk) => {
+                    chunks.push(chunk);
+                });
+                this.message.on('end', () => {
+                    resolve(Buffer.concat(chunks));
+                });
+            }));
+        });
+    }
 }
 exports.HttpClientResponse = HttpClientResponse;
 function isHttps(requestUrl) {
@@ -4122,7 +4135,13 @@ function getProxyUrl(reqUrl) {
         }
     })();
     if (proxyVar) {
-        return new URL(proxyVar);
+        try {
+            return new URL(proxyVar);
+        }
+        catch (_a) {
+            if (!proxyVar.startsWith('http://') && !proxyVar.startsWith('https://'))
+                return new URL(`http://${proxyVar}`);
+        }
     }
     else {
         return undefined;
@@ -4437,17 +4456,17 @@ exports.isConventionalCommit = isConventionalCommit;
  */
 function getConventionalCommit(commit, options) {
     var _a, _b, _c, _d, _e, _f;
-    const ConventionalCommitRegex = new RegExp(/^(?<type>[^(!:]*)(?<scope>\(.*\))?(?<breaking>\s*!)?(?<separator>\s*:)?(?<spacing>\s*)(?<subject>.*)?$/);
+    const ConventionalCommitRegex = new RegExp(/^(?<type>[^(!:]*)(?<scope>\([^)]*\))?(?<breaking>\s*!)?(?<separator>\s*:)?(?<spacing>\s*)(?<subject>.*)?$/);
     const match = ConventionalCommitRegex.exec(commit.subject);
     let conventionalCommit = {
         commit: commit,
-        type: { index: 0, value: (_a = match === null || match === void 0 ? void 0 : match.groups) === null || _a === void 0 ? void 0 : _a.type },
-        scope: { index: 0, value: (_b = match === null || match === void 0 ? void 0 : match.groups) === null || _b === void 0 ? void 0 : _b.scope },
-        breaking: { index: 0, value: (_c = match === null || match === void 0 ? void 0 : match.groups) === null || _c === void 0 ? void 0 : _c.breaking },
-        seperator: { index: 0, value: (_d = match === null || match === void 0 ? void 0 : match.groups) === null || _d === void 0 ? void 0 : _d.separator },
-        spacing: { index: 0, value: (_e = match === null || match === void 0 ? void 0 : match.groups) === null || _e === void 0 ? void 0 : _e.spacing },
-        description: { index: 0, value: (_f = match === null || match === void 0 ? void 0 : match.groups) === null || _f === void 0 ? void 0 : _f.subject },
-        body: { index: 0, value: commit.body },
+        type: { index: 1, value: (_a = match === null || match === void 0 ? void 0 : match.groups) === null || _a === void 0 ? void 0 : _a.type },
+        scope: { index: 1, value: (_b = match === null || match === void 0 ? void 0 : match.groups) === null || _b === void 0 ? void 0 : _b.scope },
+        breaking: { index: 1, value: (_c = match === null || match === void 0 ? void 0 : match.groups) === null || _c === void 0 ? void 0 : _c.breaking },
+        seperator: { index: 1, value: (_d = match === null || match === void 0 ? void 0 : match.groups) === null || _d === void 0 ? void 0 : _d.separator },
+        spacing: { index: 1, value: (_e = match === null || match === void 0 ? void 0 : match.groups) === null || _e === void 0 ? void 0 : _e.spacing },
+        description: { index: 1, value: (_f = match === null || match === void 0 ? void 0 : match.groups) === null || _f === void 0 ? void 0 : _f.subject },
+        body: { index: 1, value: commit.body },
     };
     function intializeIndices(commit) {
         var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k;
@@ -4751,7 +4770,7 @@ function createError(commit, description, highlight, type) {
         .id(commit.commit.hash)
         .error(highlightString(description, highlight))
         .lineNumber(1)
-        .caret(data.index, ((_a = data.value) === null || _a === void 0 ? void 0 : _a.length) || 0)
+        .caret(data.index, ((_a = data.value) === null || _a === void 0 ? void 0 : _a.length) || 1)
         .context(commit.commit.body !== undefined && commit.commit.body.split("\n").length >= 1
         ? [commit.commit.subject, "", ...commit.commit.body.split("\n")]
         : [commit.commit.subject], 1);
@@ -4899,9 +4918,9 @@ exports.commitRules = [new CC01(), new CC04(), new CC05(), new EC01(), new EC02(
 "use strict";
 
 /*
-SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
-SPDX-License-Identifier: MIT
-*/
+ * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
+ */
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
@@ -4921,7 +4940,7 @@ const assert_1 = __importDefault(__nccwpck_require__(9491));
  *    10 |     - uses: actions/setup-node@v2
  *    11 |       with:
  *
- * The format is loosely baed onthe LLVM "Expressive Diagnostics" specification, with
+ * The format is loosely based on the LLVM "Expressive Diagnostics" specification, with
  * additional support for context.
  *
  * @class ExpressiveMessage
@@ -4934,7 +4953,7 @@ const assert_1 = __importDefault(__nccwpck_require__(9491));
  * @function context Context around the error
  * @function toString Returns the formatted message
  *
- * @see https://clang.llvm.org/docs/ClangFormatStyleOptions.html#expressive-diagnostic-formatting
+ * @see https://clang.llvm.org/diagnostics.html
  */
 class ExpressiveMessage extends Error {
     constructor(message) {
@@ -4943,8 +4962,8 @@ class ExpressiveMessage extends Error {
         this._id = undefined;
         this._type = "note";
         this._message = undefined;
-        this._lineNumber = 0;
-        this._caret = { index: 0, length: 0 };
+        this._lineNumber = 1;
+        this._caret = { index: 1, length: 1 };
         if (message) {
             this.id(message.id);
             switch (message.type) {
@@ -4954,14 +4973,15 @@ class ExpressiveMessage extends Error {
                 case "warning":
                     this.warning(message.message);
                     break;
-                case "note" || 0:
+                case "note":
+                case undefined:
                     this.note(message.message);
                     break;
             }
-            this.lineNumber((_a = message.lineNumber) !== null && _a !== void 0 ? _a : 0);
+            this.lineNumber((_a = message.lineNumber) !== null && _a !== void 0 ? _a : 1);
             if (message.context !== undefined)
                 this.context(message.context.lines, message.context.index);
-            this.caret((_c = (_b = message.caret) === null || _b === void 0 ? void 0 : _b.index) !== null && _c !== void 0 ? _c : 0, (_e = (_d = message.caret) === null || _d === void 0 ? void 0 : _d.length) !== null && _e !== void 0 ? _e : 0);
+            this.caret((_c = (_b = message.caret) === null || _b === void 0 ? void 0 : _b.index) !== null && _c !== void 0 ? _c : 1, (_e = (_d = message.caret) === null || _d === void 0 ? void 0 : _d.length) !== null && _e !== void 0 ? _e : 1);
         }
     }
     /**
@@ -5013,8 +5033,8 @@ class ExpressiveMessage extends Error {
      * @returns this
      */
     lineNumber(lineNumber) {
-        if (lineNumber < 0)
-            throw new RangeError("Line number must be greater or equal to 0.");
+        if (lineNumber <= 0)
+            throw new RangeError("Line number must be greater than 0.");
         this._lineNumber = lineNumber;
         this.update();
         return this;
@@ -5026,13 +5046,13 @@ class ExpressiveMessage extends Error {
      * @returns this
      */
     caret(columnNumber, length) {
-        if (columnNumber < 0)
-            throw new RangeError("Column number must be greater or equal to 0.");
-        if (length !== undefined && length < 0)
-            throw new RangeError("Caret length must be greater or equal to 0.");
+        if (columnNumber <= 0)
+            throw new RangeError("Column number must be greater than 0.");
+        if (length !== undefined && length <= 0)
+            throw new RangeError("Caret length must be greater than 0.");
         this._caret = {
             index: columnNumber,
-            length: length !== null && length !== void 0 ? length : 0,
+            length: length !== null && length !== void 0 ? length : 1,
         };
         this.update();
         return this;
@@ -5054,8 +5074,8 @@ class ExpressiveMessage extends Error {
      * @returns this
      */
     context(lines, start) {
-        if (start < 0)
-            throw new RangeError("Initial line number must be greater or equal to 0.");
+        if (start < 1)
+            throw new RangeError("Initial line number must be greater than 0.");
         if (typeof lines === "string")
             lines = lines.split("\n");
         this._context = { index: start, lines: lines.length > 0 ? lines : [] };
@@ -5067,8 +5087,9 @@ class ExpressiveMessage extends Error {
      */
     update() {
         const GREEN = "\x1b[0;32m";
+        const LIGHT_PURPLE = "\x1b[1;35m";
         const RED = "\x1b[1;31m";
-        this.message = `\x1b[1m${this._id}:${this._lineNumber}:${this._caret.index}: ${this._type === "error" ? RED : GREEN}${this._type}:\x1b[0m\x1b[1m ${this._message}\x1b[0m`;
+        this.message = `\x1b[1m${this._id}:${this._lineNumber}:${this._caret.index}: ${this._type === "error" ? RED : this._type === "warning" ? LIGHT_PURPLE : GREEN}${this._type}:\x1b[0m\x1b[1m ${this._message}\x1b[0m`;
         if (this._context === undefined)
             return;
         this.message += "\n\n";
@@ -5081,9 +5102,9 @@ class ExpressiveMessage extends Error {
                 formattedLine = `\u001b[38;5;245m${formattedLine}\u001b[0m`;
             this.message += formattedLine;
             if (this._lineNumber === lineNumber) {
-                this.message += `  ${" ".repeat(maxWidth)} | ${" ".repeat(this._caret.index)}\u001b[32;1m^${"-".repeat(this._caret.length > 0 ? this._caret.length - 1 : 0)}\u001b[0m\n`;
+                this.message += `  ${" ".repeat(maxWidth)} | ${" ".repeat(this._caret.index - 1)}\u001b[32;1m^${"-".repeat(this._caret.length > 0 ? this._caret.length - 1 : 0)}\u001b[0m\n`;
                 if (this._hint !== undefined) {
-                    this.message += `  ${" ".repeat(maxWidth)} | ${" ".repeat(this._caret.index)}${this._hint}\n`;
+                    this.message += `  ${" ".repeat(maxWidth)} | ${" ".repeat(this._caret.index - 1)}${this._hint}\n`;
                 }
             }
         });
@@ -5105,6 +5126,24 @@ class ExpressiveMessage extends Error {
             throw new Error("Cannot specify a hint without a caret.");
         return this.message;
     }
+    /**
+     * Returns the Expressive Diagnostics message as a JSON object.
+     */
+    toJSON() {
+        if (this._id === undefined)
+            throw new Error("No identifier (i.e. filename) has been provided.");
+        if (this._message === undefined)
+            throw new Error("No message has been specified.");
+        return {
+            id: this._id,
+            type: this._type,
+            message: this._message,
+            lineNumber: this._lineNumber,
+            caret: this._caret,
+            hint: this._hint,
+            context: this._context,
+        };
+    }
 }
 exports.ExpressiveMessage = ExpressiveMessage;
 
@@ -5117,13 +5156,568 @@ exports.ExpressiveMessage = ExpressiveMessage;
 "use strict";
 
 /*
-SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
-SPDX-License-Identifier: MIT
-*/
+ * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
+ */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.ExpressiveMessage = void 0;
+exports.extractFromSarif = exports.extractFromFile = exports.ExpressiveMessage = void 0;
 var diagnostics_1 = __nccwpck_require__(275);
 Object.defineProperty(exports, "ExpressiveMessage", ({ enumerable: true, get: function () { return diagnostics_1.ExpressiveMessage; } }));
+var parser_1 = __nccwpck_require__(9753);
+Object.defineProperty(exports, "extractFromFile", ({ enumerable: true, get: function () { return parser_1.extractFromFile; } }));
+Object.defineProperty(exports, "extractFromSarif", ({ enumerable: true, get: function () { return parser_1.extractFromSarif; } }));
+
+
+/***/ }),
+
+/***/ 9753:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+/*
+ * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.extractFromFile = exports.extractFromSarif = void 0;
+const readline_1 = __importDefault(__nccwpck_require__(4521));
+const fs_1 = __importDefault(__nccwpck_require__(7147));
+const diagnostics_1 = __nccwpck_require__(275);
+const sarif = __importStar(__nccwpck_require__(1496));
+const LLVM_EXPRESSIVE_DIAGNOSTICS_REGEX = new RegExp("(?<file>[\\w,\\s-.]+):(?<lineNumber>[0-9]+):(?<columnNumber>[0-9]+): (?<messageType>(error|warning|note)): (?<message>(.*))");
+/**
+ * Extracts Expressive Diagnostic messages from SARIF.
+ *
+ * NOTE: currently we only support:
+ *   - plain text files
+ *   - the results of the last run
+ *
+ * @param sarif The SARIF to extract messages from.
+ * @param run Index of run, defaults to the last run.
+ *
+ * @returns Async Generator of Expressive Messages.
+ */
+function* extractFromSarif(sarif, run = undefined) {
+    var _a, _b, _c, _d, _e, _f, _g, _h;
+    const sarifObj = sarif.properties();
+    if (run === undefined) {
+        run = sarifObj.runs.length - 1;
+    }
+    const results = (_a = sarifObj.runs[run].results) !== null && _a !== void 0 ? _a : [];
+    for (const result of results) {
+        for (const location of (_b = result.locations) !== null && _b !== void 0 ? _b : []) {
+            if (result.message.text === undefined || location.physicalLocation === undefined) {
+                continue;
+            }
+            const msg = new diagnostics_1.ExpressiveMessage({
+                id: (_d = (_c = location.physicalLocation.artifactLocation) === null || _c === void 0 ? void 0 : _c.uri) !== null && _d !== void 0 ? _d : "",
+                message: result.message.text,
+                type: ((_e = result.level) !== null && _e !== void 0 ? _e : "warning"),
+            });
+            if (location.physicalLocation.region) {
+                const region = location.physicalLocation.region;
+                const line = (_f = region.startLine) !== null && _f !== void 0 ? _f : 1;
+                const column = (_g = region.startColumn) !== null && _g !== void 0 ? _g : 1;
+                const length = region.endColumn && column ? region.endColumn - column : 1;
+                const snippet = (_h = region.snippet) === null || _h === void 0 ? void 0 : _h.text;
+                msg.lineNumber(line).caret(column !== null && column !== void 0 ? column : 1, length !== null && length !== void 0 ? length : 1);
+                if (snippet !== undefined) {
+                    msg.context(snippet, line);
+                }
+            }
+            yield msg;
+        }
+    }
+}
+exports.extractFromSarif = extractFromSarif;
+/**
+ * Extracts Expressive Diagnostic messages from a raw file.
+ * This can be used to extract messages from compiler output
+ *
+ * @param filePath Path to file to extract messages from.
+ */
+async function* extractRaw(filePath) {
+    let currentMessage = undefined;
+    let matchIndex = 0;
+    const lineReader = readline_1.default.createInterface({
+        input: fs_1.default.createReadStream(filePath),
+        crlfDelay: Infinity,
+    });
+    for await (const line of lineReader) {
+        const match = LLVM_EXPRESSIVE_DIAGNOSTICS_REGEX.exec(line);
+        if (match && match.groups) {
+            currentMessage = new diagnostics_1.ExpressiveMessage({
+                id: match.groups.file,
+                message: match.groups.message,
+                type: match.groups.messageType,
+                lineNumber: parseInt(match.groups.lineNumber),
+                caret: { index: parseInt(match.groups.columnNumber), length: 1 },
+            });
+            matchIndex = line.length - line.trimStart().length;
+        }
+        else if (currentMessage) {
+            const lineNumber = currentMessage.toJSON().lineNumber;
+            if (lineNumber !== undefined) {
+                currentMessage = currentMessage.context(line.substring(matchIndex), lineNumber);
+            }
+            yield currentMessage;
+            currentMessage = undefined;
+        }
+    }
+    if (currentMessage) {
+        yield currentMessage;
+    }
+}
+/**
+ * Extracts Expressive Diagnostic messages from a file.
+ * This can be used to extract messages from compile output
+ *
+ * @param filePath Path to file to extract messages from.
+ * @returns Async Generator of Expressive Messages.
+ *
+ * @see https://clang.llvm.org/diagnostics.html
+ */
+async function* extractFromFile(filePath) {
+    if (filePath.endsWith(".sarif") || filePath.endsWith(".json.sarif")) {
+        const sarifData = sarif.Log.fromFile(filePath);
+        for (const message of extractFromSarif(sarifData)) {
+            yield message;
+        }
+        return;
+    }
+    for await (const message of extractRaw(filePath)) {
+        yield message;
+    }
+}
+exports.extractFromFile = extractFromFile;
+
+
+/***/ }),
+
+/***/ 1496:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+/**
+ * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.Rule = exports.Result = exports.Tool = exports.Run = exports.Log = void 0;
+var log_1 = __nccwpck_require__(3957);
+Object.defineProperty(exports, "Log", ({ enumerable: true, get: function () { return log_1.Log; } }));
+var run_1 = __nccwpck_require__(3205);
+Object.defineProperty(exports, "Run", ({ enumerable: true, get: function () { return run_1.Run; } }));
+var tool_1 = __nccwpck_require__(3431);
+Object.defineProperty(exports, "Tool", ({ enumerable: true, get: function () { return tool_1.Tool; } }));
+var result_1 = __nccwpck_require__(6159);
+Object.defineProperty(exports, "Result", ({ enumerable: true, get: function () { return result_1.Result; } }));
+var rule_1 = __nccwpck_require__(2917);
+Object.defineProperty(exports, "Rule", ({ enumerable: true, get: function () { return rule_1.Rule; } }));
+
+
+/***/ }),
+
+/***/ 6027:
+/***/ ((__unused_webpack_module, exports) => {
+
+"use strict";
+
+/**
+ * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.ISarif = void 0;
+class ISarif {
+    constructor(data) {
+        this._data = data;
+    }
+    /** Getter for a property by name */
+    get(property) {
+        const properties = Object.keys(this._data);
+        if (properties.includes(property)) {
+            return this._data[property];
+        }
+        throw new Error(`Property '${property}' does not exist.`);
+    }
+    /** Returns all SARIF properties */
+    properties() {
+        return this._data;
+    }
+}
+exports.ISarif = ISarif;
+
+
+/***/ }),
+
+/***/ 3957:
+/***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
+
+"use strict";
+
+/**
+ * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.prototype.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.Log = void 0;
+const fs = __importStar(__nccwpck_require__(7147));
+const run_1 = __nccwpck_require__(3205);
+const interfaces_1 = __nccwpck_require__(6027);
+const tool_1 = __nccwpck_require__(3431);
+const result_1 = __nccwpck_require__(6159);
+/** Static Analysis Results Format (SARIF) Version 2.1.0 */
+class Log extends interfaces_1.ISarif {
+    constructor() {
+        super({
+            $schema: "http://json.schemastore.org/sarif-2.1.0.json",
+            version: "2.1.0",
+            runs: []
+        });
+    }
+    /**
+     * Adds a single run to the SARIF log
+     */
+    addRun(run) {
+        this._data.runs.push(run.properties());
+        return this;
+    }
+    /**
+     * Creates a new SARIF log object from a file
+     *
+     * @param filePath The path to the SARIF file
+     * @returns A new SARIF log object
+     */
+    static fromFile(filePath) {
+        const data = JSON.parse(fs.readFileSync(filePath, { encoding: "utf-8" }));
+        const log = new Log();
+        if (Object.keys(data).includes("runs") && Array.isArray(data.runs)) {
+            for (const sarifRun of data.runs) {
+                const tool = new tool_1.Tool(sarifRun.tool.driver.name, sarifRun.tool.driver);
+                const run = new run_1.Run(tool);
+                if (Object.keys(sarifRun).includes("results") && Array.isArray(sarifRun.results)) {
+                    for (const result of sarifRun.results) {
+                        const res = new result_1.Result(result.message, result);
+                        run.addResult(res);
+                    }
+                }
+                log.addRun(run);
+            }
+        }
+        return log;
+    }
+}
+exports.Log = Log;
+
+
+/***/ }),
+
+/***/ 6159:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+/**
+ * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.Result = void 0;
+const interfaces_1 = __nccwpck_require__(6027);
+/** A result produced by an analysis tool. */
+class Result extends interfaces_1.ISarif {
+    /** A result produced by an analysis tool. */
+    constructor(message, options = {}) {
+        const msg = typeof message === "string" ? { text: message } : message;
+        super({
+            message: msg,
+            ...options
+        });
+    }
+    /** The stable, unique identifier of the rule, if any, to which this result is relevant. */
+    ruleId(ruleId) {
+        this._data.ruleId = ruleId;
+        return this;
+    }
+    /** A value specifying the severity level of the result. */
+    level(level) {
+        this._data.level = level;
+        return this;
+    }
+    /** Encapsulates a message intended to be read by the end user. */
+    message(message) {
+        this._data.message = typeof message === "string" ? { text: message } : message;
+        return this;
+    }
+    /**
+     * Extends the set of locations where the result was detected. Specify only one location
+     * unless the problem indicated by the result can only be corrected by making a change
+     * at every specified location.
+     */
+    addLocation(location) {
+        var _a;
+        if (this._data.locations === undefined) {
+            this._data.locations = [];
+        }
+        this._data.locations.push(location);
+        this._data.occurrenceCount = ((_a = this._data.occurrenceCount) !== null && _a !== void 0 ? _a : 0) + 1;
+        return this;
+    }
+}
+exports.Result = Result;
+
+
+/***/ }),
+
+/***/ 2917:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+/**
+ * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.Rule = void 0;
+const interfaces_1 = __nccwpck_require__(6027);
+/** Metadata that describes a specific report produced by the tool, as part of the analysis it provides or its runtime reporting. */
+class Rule extends interfaces_1.ISarif {
+    /** Metadata that describes a specific report produced by the tool, as part of the analysis it provides or its runtime reporting. */
+    constructor(id, options = {}) {
+        const short = typeof options.shortDescription === "string" ? { text: options.shortDescription } : options.shortDescription;
+        const full = typeof options.fullDescription === "string" ? { text: options.fullDescription } : options.fullDescription;
+        if (short === undefined && full === undefined) {
+            super({ id: id });
+        }
+        else if (short !== undefined && full === undefined) {
+            super({
+                id: id,
+                shortDescription: short
+            });
+        }
+        else if (short === undefined && full !== undefined) {
+            super({
+                id: id,
+                fullDescription: full
+            });
+        }
+        else {
+            super({
+                id: id,
+                shortDescription: short,
+                fullDescription: full
+            });
+        }
+    }
+    /** A report identifier that is understandable to an end user. */
+    name(name) {
+        this._data.name = name;
+        return this;
+    }
+    /**
+     * A concise description of the report. Should be a single sentence that is understandable when visible
+     * space is limited to a single line of text.
+     */
+    shortDescription(shortDescription) {
+        this._data.shortDescription = typeof shortDescription === "string" ? { text: shortDescription } : shortDescription;
+        return this;
+    }
+    /**
+     * A description of the report. Should, as far as possible, provide details sufficient to enable resolution
+     * of any problem indicated by the result.
+     */
+    fullDescription(fullDescription) {
+        this._data.fullDescription = typeof fullDescription === "string" ? { text: fullDescription } : fullDescription;
+        return this;
+    }
+    /** A URI where the primary documentation for the report can be found. */
+    helpUri(helpUri) {
+        this._data.helpUri = helpUri;
+        return this;
+    }
+}
+exports.Rule = Rule;
+
+
+/***/ }),
+
+/***/ 3205:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+/**
+ * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.Run = void 0;
+const interfaces_1 = __nccwpck_require__(6027);
+/** Describes a single run of an analysis tool, and contains the reported output of that run. */
+class Run extends interfaces_1.ISarif {
+    /**
+     * Describes a single run of an analysis tool, and contains the reported output of that run.
+     * @param tool The tool or tool pipeline that generated the results in this run.
+     */
+    constructor(tool) {
+        super({
+            tool: tool.properties()
+        });
+    }
+    /**
+     * Information about the tool or tool pipeline that generated the results in this run. A run can only
+     * contain results produced by a single tool or tool pipeline. A run can aggregate results from multiple
+     * log files, as long as context around the tool run (tool command-line arguments and the like) is
+     * identical for all aggregated files.
+     */
+    tool(tool) {
+        this._data.tool = tool.properties();
+        return this;
+    }
+    /**
+     * Extends the set of results contained in an SARIF log. The results array can be omitted when a run
+     * is solely exporting rules metadata. It must be present (but may be empty) if a log file represents
+     * an actual scan.
+     */
+    addResult(result) {
+        var _a, _b, _c, _d;
+        if (this._data.results === undefined) {
+            this._data.results = [];
+        }
+        for (const item of this._data.results) {
+            if (item.message.text === result.properties().message.text) {
+                (_a = item.locations) === null || _a === void 0 ? void 0 : _a.push(...(_b = result.properties().locations) !== null && _b !== void 0 ? _b : []);
+                item.occurrenceCount = ((_c = item.occurrenceCount) !== null && _c !== void 0 ? _c : 1) + ((_d = result.properties().occurrenceCount) !== null && _d !== void 0 ? _d : 1);
+                return this;
+            }
+        }
+        this._data.results.push(result.properties());
+        return this;
+    }
+}
+exports.Run = Run;
+
+
+/***/ }),
+
+/***/ 3431:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+/**
+ * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.Tool = void 0;
+const interfaces_1 = __nccwpck_require__(6027);
+/** The analysis tool that was run. */
+class Tool extends interfaces_1.ISarif {
+    //private _data: sarif.Tool;
+    constructor(name, options = {}) {
+        super({
+            driver: {
+                name: name,
+                ...options
+            }
+        });
+    }
+    /** The name of the tool component. */
+    name(name) {
+        this._data.driver.name = name;
+        return this;
+    }
+    /** The organization or company that produced the tool component. */
+    organization(organization) {
+        this._data.driver.organization = organization;
+        return this;
+    }
+    /** The tool component version, in whatever format the component natively provides. */
+    version(version) {
+        this._data.driver.version = version;
+        return this;
+    }
+    /** The absolute URI at which information about this version of the tool component can be found. */
+    informationUri(informationUri) {
+        this._data.driver.informationUri = informationUri;
+        return this;
+    }
+    /** Extends the list of rules relevant to the analysis performed by the tool component. */
+    addRule(rule) {
+        if (this._data.driver.rules === undefined) {
+            this._data.driver.rules = [];
+        }
+        if (this._data.driver.rules.some(r => r.id === rule.get("id"))) {
+            this._data.driver.rules = this._data.driver.rules.filter(r => r.id !== rule.get("id"));
+        }
+        this._data.driver.rules.push(rule.properties());
+        return this;
+    }
+    /** Getter for a property by name */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    get(property) {
+        const properties = Object.keys(this._data.driver);
+        if (properties.includes(property)) {
+            return this._data.driver[property];
+        }
+        throw new Error(`Property '${property}' does not exist.`);
+    }
+}
+exports.Tool = Tool;
 
 
 /***/ }),
@@ -18766,6 +19360,14 @@ module.exports = require("perf_hooks");
 
 "use strict";
 module.exports = require("punycode");
+
+/***/ }),
+
+/***/ 4521:
+/***/ ((module) => {
+
+"use strict";
+module.exports = require("readline");
 
 /***/ }),
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,9 +75,9 @@
       }
     },
     "node_modules/@actions/http-client": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.1.0.tgz",
-      "integrity": "sha512-BonhODnXr3amchh4qkmjPMUO8mFi/zLaaCeCAJZqch8iQqyDnVIkySjB38VHAC8IJ+bnlgfOqlhpyCUZHlQsqw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.1.1.tgz",
+      "integrity": "sha512-qhrkRMB40bbbLo7gF+0vu+X+UawOvQQqNAA/5Unx774RS8poaOhThDOG6BGmxvAnxhQnDp2BG/ZUm65xZILTpw==",
       "dependencies": {
         "tunnel": "^0.0.6"
       }
@@ -96,15 +96,87 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.5.tgz",
-      "integrity": "sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==",
+      "version": "7.22.10",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.10.tgz",
+      "integrity": "sha512-/KKIMG4UEL35WmI9OlvMhurwtytjvXoFcGNrOvyG9zIzA8YmPjVtIZUf7b05+TPO7G7/GEmLHDaoCgACHl9hhA==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.22.5"
+        "@babel/highlight": "^7.22.10",
+        "chalk": "^2.4.2"
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true
+    },
+    "node_modules/@babel/code-frame/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@babel/compat-data": {
@@ -117,21 +189,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.22.9",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.9.tgz",
-      "integrity": "sha512-G2EgeufBcYw27U4hhoIwFcgc1XU7TlXJ3mv04oOv1WCuo900U/anZSPzEqNjwdjgffkk2Gs0AN0dW1CKVLcG7w==",
+      "version": "7.22.10",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.10.tgz",
+      "integrity": "sha512-fTmqbbUBAwCcre6zPzNngvsI0aNrPZe77AeqvDxWM9Nm+04RrJ3CAmGHA9f7lJQY6ZMhRztNemy4uslDxTX4Qw==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
-        "@babel/code-frame": "^7.22.5",
-        "@babel/generator": "^7.22.9",
-        "@babel/helper-compilation-targets": "^7.22.9",
+        "@babel/code-frame": "^7.22.10",
+        "@babel/generator": "^7.22.10",
+        "@babel/helper-compilation-targets": "^7.22.10",
         "@babel/helper-module-transforms": "^7.22.9",
-        "@babel/helpers": "^7.22.6",
-        "@babel/parser": "^7.22.7",
+        "@babel/helpers": "^7.22.10",
+        "@babel/parser": "^7.22.10",
         "@babel/template": "^7.22.5",
-        "@babel/traverse": "^7.22.8",
-        "@babel/types": "^7.22.5",
+        "@babel/traverse": "^7.22.10",
+        "@babel/types": "^7.22.10",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -162,12 +234,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.22.9",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.9.tgz",
-      "integrity": "sha512-KtLMbmicyuK2Ak/FTCJVbDnkN1SlT8/kceFTiuDiiRUUSMnHMidxSCdG4ndkTOHHpoomWe/4xkvHkEOncwjYIw==",
+      "version": "7.22.10",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.10.tgz",
+      "integrity": "sha512-79KIf7YiWjjdZ81JnLujDRApWtl7BxTqWD88+FFdQEIOG8LJ0etDOM7CXuIgGJa55sGOwZVwuEsaLEm0PJ5/+A==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.22.5",
+        "@babel/types": "^7.22.10",
         "@jridgewell/gen-mapping": "^0.3.2",
         "@jridgewell/trace-mapping": "^0.3.17",
         "jsesc": "^2.5.1"
@@ -177,9 +249,9 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.22.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.9.tgz",
-      "integrity": "sha512-7qYrNM6HjpnPHJbopxmb8hSPoZ0gsX8IvUS32JGVoy+pU9e5N0nLr1VjJoR6kA4d9dmGLxNYOjeB8sUDal2WMw==",
+      "version": "7.22.10",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.10.tgz",
+      "integrity": "sha512-JMSwHD4J7SLod0idLq5PKgI+6g/hLD/iuWBq08ZX49xE14VpVEojJ5rHWptpirV2j020MvypRLAXAO50igCJ5Q==",
       "dev": true,
       "dependencies": {
         "@babel/compat-data": "^7.22.9",
@@ -190,9 +262,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
@@ -330,27 +399,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.22.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.22.6.tgz",
-      "integrity": "sha512-YjDs6y/fVOYFV8hAf1rxd1QvR9wJe1pDBZ2AREKq/SDayfPzgk0PBnVuTCE5X1acEpMMNOVUqoe+OwiZGJ+OaA==",
+      "version": "7.22.10",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.22.10.tgz",
+      "integrity": "sha512-a41J4NW8HyZa1I1vAndrraTlPZ/eZoga2ZgS7fEr0tZJGVU4xqdE80CEm0CcNjha5EZ8fTBYLKHF0kqDUuAwQw==",
       "dev": true,
       "dependencies": {
         "@babel/template": "^7.22.5",
-        "@babel/traverse": "^7.22.6",
-        "@babel/types": "^7.22.5"
+        "@babel/traverse": "^7.22.10",
+        "@babel/types": "^7.22.10"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.5.tgz",
-      "integrity": "sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==",
+      "version": "7.22.10",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.10.tgz",
+      "integrity": "sha512-78aUtVcT7MUscr0K5mIEnkwxPE0MaxkR5RxRwuHaQ+JuU5AmTPhY+do2mdzVTnIJJpyBglql2pehuBIWHug+WQ==",
       "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.22.5",
-        "chalk": "^2.0.0",
+        "chalk": "^2.4.2",
         "js-tokens": "^4.0.0"
       },
       "engines": {
@@ -429,9 +498,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.22.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.7.tgz",
-      "integrity": "sha512-7NF8pOkHP5o2vpmGgNGcfAeCvOYhGLyA3Z4eBQkT1RJlWu47n63bCs93QfJ2hIAFCil7L5P2IWhs1oToVgrL0Q==",
+      "version": "7.22.10",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.10.tgz",
+      "integrity": "sha512-lNbdGsQb9ekfsnjFGhEiF4hfFqGgfOP3H3d27re3n+CGhNuTSUEQdfWk556sTLNTloczcdM5TYF2LhzmDQKyvQ==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -632,19 +701,19 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.22.8",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.8.tgz",
-      "integrity": "sha512-y6LPR+wpM2I3qJrsheCTwhIinzkETbplIgPBbwvqPKc+uljeA5gP+3nP8irdYt1mjQaDnlIcG+dw8OjAco4GXw==",
+      "version": "7.22.10",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.10.tgz",
+      "integrity": "sha512-Q/urqV4pRByiNNpb/f5OSv28ZlGJiFiiTh+GAHktbIrkPhPbl90+uW6SmpoLyZqutrg9AEaEf3Q/ZBRHBXgxig==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.22.5",
-        "@babel/generator": "^7.22.7",
+        "@babel/code-frame": "^7.22.10",
+        "@babel/generator": "^7.22.10",
         "@babel/helper-environment-visitor": "^7.22.5",
         "@babel/helper-function-name": "^7.22.5",
         "@babel/helper-hoist-variables": "^7.22.5",
         "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.22.7",
-        "@babel/types": "^7.22.5",
+        "@babel/parser": "^7.22.10",
+        "@babel/types": "^7.22.10",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -662,9 +731,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.5.tgz",
-      "integrity": "sha512-zo3MIHGOkPOfoRXitsgHLjEXmlDaD/5KU1Uzuc9GNiZPhSqVxVRtxuPaSBZDsYZ9qV88AjtMtWW7ww98loJ9KA==",
+      "version": "7.22.10",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.10.tgz",
+      "integrity": "sha512-obaoigiLrlDZ7TUQln/8m4mSqIW2QFeOrCQc9r+xsaHGNoplVNYlRVpsfE8Vj35GEm2ZH4ZhrNYogs/3fj85kg==",
       "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.22.5",
@@ -682,17 +751,28 @@
       "dev": true
     },
     "node_modules/@dev-build-deploy/commit-it": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@dev-build-deploy/commit-it/-/commit-it-0.4.1.tgz",
-      "integrity": "sha512-/Mio9kqeA8KY4hWVCHjQWG0/m+lwBjxJ9jgfihYoi6PVXKC/H/KPAeIBKg+gIJAn7f4jk25nNDRgmdmCur3nDg==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@dev-build-deploy/commit-it/-/commit-it-0.4.2.tgz",
+      "integrity": "sha512-s1Xw5IsGQBBdd1hcxE8WnSGSl32b9mEoGHtlOBCovfrD/8O1TRIutEFg27lbnNhBBUL2GXtQjqmYx5R6uS4Zjg==",
       "dependencies": {
         "@dev-build-deploy/diagnose-it": "<1.0.0"
       }
     },
     "node_modules/@dev-build-deploy/diagnose-it": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@dev-build-deploy/diagnose-it/-/diagnose-it-0.4.2.tgz",
+      "integrity": "sha512-yhEWjsNMdbEsrIc8yp6ahZLGRfIlGRUe3odImgwMfgyHFNwWKKL8ivMQEZuqJ9Rs8QvN5uBaJ/bDISvkAfEdhw==",
+      "dependencies": {
+        "@dev-build-deploy/sarif-it": "<1"
+      }
+    },
+    "node_modules/@dev-build-deploy/sarif-it": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@dev-build-deploy/diagnose-it/-/diagnose-it-0.2.1.tgz",
-      "integrity": "sha512-RTCw1v4CKT0Kzs4XUlQyaSh+YQhRc1mGiFbAI+iVSjsyVOZsazuDQsKCGIAZR4NLPRcVRyK14J1XjWukUQJzYA=="
+      "resolved": "https://registry.npmjs.org/@dev-build-deploy/sarif-it/-/sarif-it-0.2.1.tgz",
+      "integrity": "sha512-NvGhCoIfoz547zRxJn9VwVzqDVxtkt5LL76uGiAIcjR2qLLwrBNOw+cd/JxyD3V7/dgWGYCv3ifwlXvC5wzC/w==",
+      "dependencies": {
+        "@types/sarif": "^2.1.4"
+      }
     },
     "node_modules/@dev-build-deploy/version-it": {
       "version": "0.3.0",
@@ -715,18 +795,18 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.5.1.tgz",
-      "integrity": "sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.6.2.tgz",
+      "integrity": "sha512-pPTNuaAG3QMH+buKyBIGJs3g/S5y0caxw0ygM3YyE6yJFySwiGGSzA+mM3KJ8QQvzeLh3blwgSonkFjgQdxzMw==",
       "dev": true,
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.0.tgz",
-      "integrity": "sha512-Lj7DECXqIVCqnqjjHMPna4vn6GJcMgul/wuS0je9OZ9gsL0zzDpKPVtcG1HaDVc+9y+qgXneTeUMbCqXJNpH1A==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.2.tgz",
+      "integrity": "sha512-+wvgpDsrB1YqAMdEUCcnTlpfVBH7Vqn6A/NT3D8WVXFIaKMlErPIZT3oCIAVCOtarRpMtelZLqJeU3t7WY6X6g==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
@@ -747,9 +827,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.44.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.44.0.tgz",
-      "integrity": "sha512-Ag+9YM4ocKQx9AarydN0KY2j0ErMHNIocPDrVo8zAE44xLTjEtz81OdR68/cydGtk6m6jDb5Za3r2useMzYmSw==",
+      "version": "8.47.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.47.0.tgz",
+      "integrity": "sha512-P6omY1zv5MItm93kLM8s2vr1HICJH8v0dvddDhysbIuZ+vcjOHg5Zbkf1mTkcmi2JA9oBG2anOkRnW8WJTS8Og==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -897,16 +977,16 @@
       }
     },
     "node_modules/@jest/console": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.6.1.tgz",
-      "integrity": "sha512-Aj772AYgwTSr5w8qnyoJ0eDYvN6bMsH3ORH1ivMotrInHLKdUz6BDlaEXHdM6kODaBIkNIyQGzsMvRdOv7VG7Q==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.6.2.tgz",
+      "integrity": "sha512-0N0yZof5hi44HAR2pPS+ikJ3nzKNoZdVu8FffRf3wy47I7Dm7etk/3KetMdRUqzVd16V4O2m2ISpNTbnIuqy1w==",
       "dev": true,
       "dependencies": {
         "@jest/types": "^29.6.1",
         "@types/node": "*",
         "chalk": "^4.0.0",
-        "jest-message-util": "^29.6.1",
-        "jest-util": "^29.6.1",
+        "jest-message-util": "^29.6.2",
+        "jest-util": "^29.6.2",
         "slash": "^3.0.0"
       },
       "engines": {
@@ -914,15 +994,15 @@
       }
     },
     "node_modules/@jest/core": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.6.1.tgz",
-      "integrity": "sha512-CcowHypRSm5oYQ1obz1wfvkjZZ2qoQlrKKvlfPwh5jUXVU12TWr2qMeH8chLMuTFzHh5a1g2yaqlqDICbr+ukQ==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.6.2.tgz",
+      "integrity": "sha512-Oj+5B+sDMiMWLhPFF+4/DvHOf+U10rgvCLGPHP8Xlsy/7QxS51aU/eBngudHlJXnaWD5EohAgJ4js+T6pa+zOg==",
       "dev": true,
       "dependencies": {
-        "@jest/console": "^29.6.1",
-        "@jest/reporters": "^29.6.1",
-        "@jest/test-result": "^29.6.1",
-        "@jest/transform": "^29.6.1",
+        "@jest/console": "^29.6.2",
+        "@jest/reporters": "^29.6.2",
+        "@jest/test-result": "^29.6.2",
+        "@jest/transform": "^29.6.2",
         "@jest/types": "^29.6.1",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
@@ -931,20 +1011,20 @@
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.9",
         "jest-changed-files": "^29.5.0",
-        "jest-config": "^29.6.1",
-        "jest-haste-map": "^29.6.1",
-        "jest-message-util": "^29.6.1",
+        "jest-config": "^29.6.2",
+        "jest-haste-map": "^29.6.2",
+        "jest-message-util": "^29.6.2",
         "jest-regex-util": "^29.4.3",
-        "jest-resolve": "^29.6.1",
-        "jest-resolve-dependencies": "^29.6.1",
-        "jest-runner": "^29.6.1",
-        "jest-runtime": "^29.6.1",
-        "jest-snapshot": "^29.6.1",
-        "jest-util": "^29.6.1",
-        "jest-validate": "^29.6.1",
-        "jest-watcher": "^29.6.1",
+        "jest-resolve": "^29.6.2",
+        "jest-resolve-dependencies": "^29.6.2",
+        "jest-runner": "^29.6.2",
+        "jest-runtime": "^29.6.2",
+        "jest-snapshot": "^29.6.2",
+        "jest-util": "^29.6.2",
+        "jest-validate": "^29.6.2",
+        "jest-watcher": "^29.6.2",
         "micromatch": "^4.0.4",
-        "pretty-format": "^29.6.1",
+        "pretty-format": "^29.6.2",
         "slash": "^3.0.0",
         "strip-ansi": "^6.0.0"
       },
@@ -961,37 +1041,37 @@
       }
     },
     "node_modules/@jest/environment": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.6.1.tgz",
-      "integrity": "sha512-RMMXx4ws+Gbvw3DfLSuo2cfQlK7IwGbpuEWXCqyYDcqYTI+9Ju3a5hDnXaxjNsa6uKh9PQF2v+qg+RLe63tz5A==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.6.2.tgz",
+      "integrity": "sha512-AEcW43C7huGd/vogTddNNTDRpO6vQ2zaQNrttvWV18ArBx9Z56h7BIsXkNFJVOO4/kblWEQz30ckw0+L3izc+Q==",
       "dev": true,
       "dependencies": {
-        "@jest/fake-timers": "^29.6.1",
+        "@jest/fake-timers": "^29.6.2",
         "@jest/types": "^29.6.1",
         "@types/node": "*",
-        "jest-mock": "^29.6.1"
+        "jest-mock": "^29.6.2"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/expect": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.6.1.tgz",
-      "integrity": "sha512-N5xlPrAYaRNyFgVf2s9Uyyvr795jnB6rObuPx4QFvNJz8aAjpZUDfO4bh5G/xuplMID8PrnuF1+SfSyDxhsgYg==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.6.2.tgz",
+      "integrity": "sha512-m6DrEJxVKjkELTVAztTLyS/7C92Y2b0VYqmDROYKLLALHn8T/04yPs70NADUYPrV3ruI+H3J0iUIuhkjp7vkfg==",
       "dev": true,
       "dependencies": {
-        "expect": "^29.6.1",
-        "jest-snapshot": "^29.6.1"
+        "expect": "^29.6.2",
+        "jest-snapshot": "^29.6.2"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/expect-utils": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.6.1.tgz",
-      "integrity": "sha512-o319vIf5pEMx0LmzSxxkYYxo4wrRLKHq9dP1yJU7FoPTB0LfAKSz8SWD6D/6U3v/O52t9cF5t+MeJiRsfk7zMw==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.6.2.tgz",
+      "integrity": "sha512-6zIhM8go3RV2IG4aIZaZbxwpOzz3ZiM23oxAlkquOIole+G6TrbeXnykxWYlqF7kz2HlBjdKtca20x9atkEQYg==",
       "dev": true,
       "dependencies": {
         "jest-get-type": "^29.4.3"
@@ -1001,47 +1081,47 @@
       }
     },
     "node_modules/@jest/fake-timers": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.6.1.tgz",
-      "integrity": "sha512-RdgHgbXyosCDMVYmj7lLpUwXA4c69vcNzhrt69dJJdf8azUrpRh3ckFCaTPNjsEeRi27Cig0oKDGxy5j7hOgHg==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.6.2.tgz",
+      "integrity": "sha512-euZDmIlWjm1Z0lJ1D0f7a0/y5Kh/koLFMUBE5SUYWrmy8oNhJpbTBDAP6CxKnadcMLDoDf4waRYCe35cH6G6PA==",
       "dev": true,
       "dependencies": {
         "@jest/types": "^29.6.1",
         "@sinonjs/fake-timers": "^10.0.2",
         "@types/node": "*",
-        "jest-message-util": "^29.6.1",
-        "jest-mock": "^29.6.1",
-        "jest-util": "^29.6.1"
+        "jest-message-util": "^29.6.2",
+        "jest-mock": "^29.6.2",
+        "jest-util": "^29.6.2"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/globals": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.6.1.tgz",
-      "integrity": "sha512-2VjpaGy78JY9n9370H8zGRCFbYVWwjY6RdDMhoJHa1sYfwe6XM/azGN0SjY8kk7BOZApIejQ1BFPyH7FPG0w3A==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.6.2.tgz",
+      "integrity": "sha512-cjuJmNDjs6aMijCmSa1g2TNG4Lby/AeU7/02VtpW+SLcZXzOLK2GpN2nLqcFjmhy3B3AoPeQVx7BnyOf681bAw==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "^29.6.1",
-        "@jest/expect": "^29.6.1",
+        "@jest/environment": "^29.6.2",
+        "@jest/expect": "^29.6.2",
         "@jest/types": "^29.6.1",
-        "jest-mock": "^29.6.1"
+        "jest-mock": "^29.6.2"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/reporters": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.6.1.tgz",
-      "integrity": "sha512-9zuaI9QKr9JnoZtFQlw4GREQbxgmNYXU6QuWtmuODvk5nvPUeBYapVR/VYMyi2WSx3jXTLJTJji8rN6+Cm4+FA==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.6.2.tgz",
+      "integrity": "sha512-sWtijrvIav8LgfJZlrGCdN0nP2EWbakglJY49J1Y5QihcQLfy7ovyxxjJBRXMNltgt4uPtEcFmIMbVshEDfFWw==",
       "dev": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^0.2.3",
-        "@jest/console": "^29.6.1",
-        "@jest/test-result": "^29.6.1",
-        "@jest/transform": "^29.6.1",
+        "@jest/console": "^29.6.2",
+        "@jest/test-result": "^29.6.2",
+        "@jest/transform": "^29.6.2",
         "@jest/types": "^29.6.1",
         "@jridgewell/trace-mapping": "^0.3.18",
         "@types/node": "*",
@@ -1055,9 +1135,9 @@
         "istanbul-lib-report": "^3.0.0",
         "istanbul-lib-source-maps": "^4.0.0",
         "istanbul-reports": "^3.1.3",
-        "jest-message-util": "^29.6.1",
-        "jest-util": "^29.6.1",
-        "jest-worker": "^29.6.1",
+        "jest-message-util": "^29.6.2",
+        "jest-util": "^29.6.2",
+        "jest-worker": "^29.6.2",
         "slash": "^3.0.0",
         "string-length": "^4.0.1",
         "strip-ansi": "^6.0.0",
@@ -1102,12 +1182,12 @@
       }
     },
     "node_modules/@jest/test-result": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.6.1.tgz",
-      "integrity": "sha512-Ynr13ZRcpX6INak0TPUukU8GWRfm/vAytE3JbJNGAvINySWYdfE7dGZMbk36oVuK4CigpbhMn8eg1dixZ7ZJOw==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.6.2.tgz",
+      "integrity": "sha512-3VKFXzcV42EYhMCsJQURptSqnyjqCGbtLuX5Xxb6Pm6gUf1wIRIl+mandIRGJyWKgNKYF9cnstti6Ls5ekduqw==",
       "dev": true,
       "dependencies": {
-        "@jest/console": "^29.6.1",
+        "@jest/console": "^29.6.2",
         "@jest/types": "^29.6.1",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "collect-v8-coverage": "^1.0.0"
@@ -1117,14 +1197,14 @@
       }
     },
     "node_modules/@jest/test-sequencer": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.6.1.tgz",
-      "integrity": "sha512-oBkC36PCDf/wb6dWeQIhaviU0l5u6VCsXa119yqdUosYAt7/FbQU2M2UoziO3igj/HBDEgp57ONQ3fm0v9uyyg==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.6.2.tgz",
+      "integrity": "sha512-GVYi6PfPwVejO7slw6IDO0qKVum5jtrJ3KoLGbgBWyr2qr4GaxFV6su+ZAjdTX75Sr1DkMFRk09r2ZVa+wtCGw==",
       "dev": true,
       "dependencies": {
-        "@jest/test-result": "^29.6.1",
+        "@jest/test-result": "^29.6.2",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.6.1",
+        "jest-haste-map": "^29.6.2",
         "slash": "^3.0.0"
       },
       "engines": {
@@ -1132,9 +1212,9 @@
       }
     },
     "node_modules/@jest/transform": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.6.1.tgz",
-      "integrity": "sha512-URnTneIU3ZjRSaf906cvf6Hpox3hIeJXRnz3VDSw5/X93gR8ycdfSIEy19FlVx8NFmpN7fe3Gb1xF+NjXaQLWg==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.6.2.tgz",
+      "integrity": "sha512-ZqCqEISr58Ce3U+buNFJYUktLJZOggfyvR+bZMaiV1e8B1SIvJbwZMrYz3gx/KAPn9EXmOmN+uB08yLCjWkQQg==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
@@ -1145,9 +1225,9 @@
         "convert-source-map": "^2.0.0",
         "fast-json-stable-stringify": "^2.1.0",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.6.1",
+        "jest-haste-map": "^29.6.2",
         "jest-regex-util": "^29.4.3",
-        "jest-util": "^29.6.1",
+        "jest-util": "^29.6.2",
         "micromatch": "^4.0.4",
         "pirates": "^4.0.4",
         "slash": "^3.0.0",
@@ -1189,9 +1269,9 @@
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
-      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
+      "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
       "dev": true,
       "engines": {
         "node": ">=6.0.0"
@@ -1213,20 +1293,14 @@
       "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.18",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.18.tgz",
-      "integrity": "sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==",
+      "version": "0.3.19",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.19.tgz",
+      "integrity": "sha512-kf37QtfW+Hwx/buWGMPcR60iF9ziHa6r/CZJIHbmcm4+0qrXiVdxegAH0F6yddEVQ7zdkjcGCgCzUu+BcbhQxw==",
       "dev": true,
       "dependencies": {
-        "@jridgewell/resolve-uri": "3.1.0",
-        "@jridgewell/sourcemap-codec": "1.4.14"
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
-    },
-    "node_modules/@jridgewell/trace-mapping/node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.14",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
-      "dev": true
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -1485,9 +1559,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.16.19",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.19.tgz",
-      "integrity": "sha512-IXl7o+R9iti9eBW4Wg2hx1xQDig183jj7YLn8F7udNceyfkbn1ZxmzZXuak20gR40D7pIkIY1kYGx5VIGbaHKA==",
+      "version": "18.17.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.5.tgz",
+      "integrity": "sha512-xNbS75FxH6P4UXTPUJp/zNPq6/xsfdJKussCWNOnz4aULWIRwMgP1LgaB5RiBnMX1DPCYenuqGZfnIAx5mbFLA==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -1496,11 +1570,10 @@
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
       "dev": true
     },
-    "node_modules/@types/prettier": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.3.tgz",
-      "integrity": "sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==",
-      "dev": true
+    "node_modules/@types/sarif": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@types/sarif/-/sarif-2.1.4.tgz",
+      "integrity": "sha512-4xKHMdg3foh3Va1fxTzY1qt8QVqmaJpGWsVvtjQrJBn+/bkig2pWFKJ4FPI2yLI4PAj0SUKiPO4Vd7ggYIMZjQ=="
     },
     "node_modules/@types/semver": {
       "version": "7.5.0",
@@ -1843,12 +1916,12 @@
       }
     },
     "node_modules/babel-jest": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.6.1.tgz",
-      "integrity": "sha512-qu+3bdPEQC6KZSPz+4Fyjbga5OODNcp49j6GKzG1EKbkfyJBxEYGVUmVGpwCSeGouG52R4EgYMLb6p9YeEEQ4A==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.6.2.tgz",
+      "integrity": "sha512-BYCzImLos6J3BH/+HvUCHG1dTf2MzmAB4jaVxHV+29RZLjR29XuYTmsf2sdDwkrb+FczkGo3kOhE7ga6sI0P4A==",
       "dev": true,
       "dependencies": {
-        "@jest/transform": "^29.6.1",
+        "@jest/transform": "^29.6.2",
         "@types/babel__core": "^7.1.14",
         "babel-plugin-istanbul": "^6.1.1",
         "babel-preset-jest": "^29.5.0",
@@ -1965,9 +2038,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.21.9",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.9.tgz",
-      "integrity": "sha512-M0MFoZzbUrRU4KNfCrDLnvyE7gub+peetoTid3TBIqtunaDJyXlwhakT+/VkvSXcfIzFfK/nkCs4nmyTmxdNSg==",
+      "version": "4.21.10",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.10.tgz",
+      "integrity": "sha512-bipEBdZfVH5/pwrvqc+Ub0kUPVfGUhlKxbvfD+z1BDnPEO/X98ruXGA1WP5ASpAFKan7Qr6j736IacbZQuAlKQ==",
       "dev": true,
       "funding": [
         {
@@ -1984,9 +2057,9 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001503",
-        "electron-to-chromium": "^1.4.431",
-        "node-releases": "^2.0.12",
+        "caniuse-lite": "^1.0.30001517",
+        "electron-to-chromium": "^1.4.477",
+        "node-releases": "^2.0.13",
         "update-browserslist-db": "^1.0.11"
       },
       "bin": {
@@ -2042,9 +2115,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001517",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001517.tgz",
-      "integrity": "sha512-Vdhm5S11DaFVLlyiKu4hiUTkpZu+y1KA/rZZqVQfOD5YdDT/eQKlkt7NaE0WGOFgX32diqt9MiP9CAiFeRklaA==",
+      "version": "1.0.30001520",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001520.tgz",
+      "integrity": "sha512-tahF5O9EiiTzwTUqAeFjIZbn4Dnqxzz7ktrgGlMYNLH43Ul26IgTMH/zvL3DG0lZxBYnlT04axvInszUsZULdA==",
       "dev": true,
       "funding": [
         {
@@ -2198,10 +2271,18 @@
       }
     },
     "node_modules/dedent": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
-      "integrity": "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==",
-      "dev": true
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.1.tgz",
+      "integrity": "sha512-+LxW+KLWxu3HW3M2w2ympwtqPrqYRzU8fqi6Fhd18fBALe15blJPI/I4+UHveMVG6lJqB4JNd4UG0S5cnVHwIg==",
+      "dev": true,
+      "peerDependencies": {
+        "babel-plugin-macros": "^3.1.0"
+      },
+      "peerDependenciesMeta": {
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -2266,9 +2347,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.467",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.467.tgz",
-      "integrity": "sha512-2qI70O+rR4poYeF2grcuS/bCps5KJh6y1jtZMDDEteyKJQrzLOEhFyXCLcHW6DTBjKjWkk26JhWoAi+Ux9A0fg==",
+      "version": "1.4.491",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.491.tgz",
+      "integrity": "sha512-ZzPqGKghdVzlQJ+qpfE+r6EB321zed7e5JsvHIlMM4zPFF8okXUkF5Of7h7F3l3cltPL0rG7YVmlp5Qro7RQLA==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -2320,27 +2401,27 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.45.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.45.0.tgz",
-      "integrity": "sha512-pd8KSxiQpdYRfYa9Wufvdoct3ZPQQuVuU5O6scNgMuOMYuxvH0IGaYK0wUFjo4UYYQQCUndlXiMbnxopwvvTiw==",
+      "version": "8.47.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.47.0.tgz",
+      "integrity": "sha512-spUQWrdPt+pRVP1TTJLmfRNJJHHZryFmptzcafwSvHsceV81djHOdnEeDmkdotZyLNjDhrOasNK8nikkoG1O8Q==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
-        "@eslint-community/regexpp": "^4.4.0",
-        "@eslint/eslintrc": "^2.1.0",
-        "@eslint/js": "8.44.0",
+        "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/eslintrc": "^2.1.2",
+        "@eslint/js": "^8.47.0",
         "@humanwhocodes/config-array": "^0.11.10",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
-        "ajv": "^6.10.0",
+        "ajv": "^6.12.4",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
         "debug": "^4.3.2",
         "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^7.2.0",
-        "eslint-visitor-keys": "^3.4.1",
-        "espree": "^9.6.0",
+        "eslint-scope": "^7.2.2",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1",
         "esquery": "^1.4.2",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -2387,9 +2468,9 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz",
-      "integrity": "sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2399,9 +2480,9 @@
       }
     },
     "node_modules/eslint/node_modules/eslint-scope": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.1.tgz",
-      "integrity": "sha512-CvefSOsDdaYYvxChovdrPo/ZGt8d5lrJWleAc1diXRKhHGiTYEI26cvo8Kle/wGnsizoCJjK73FMg1/IkIwiNA==",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
       "dev": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
@@ -2546,17 +2627,17 @@
       }
     },
     "node_modules/expect": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-29.6.1.tgz",
-      "integrity": "sha512-XEdDLonERCU1n9uR56/Stx9OqojaLAQtZf9PrCHH9Hl8YXiEIka3H4NXJ3NOIBmQJTg7+j7buh34PMHfJujc8g==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.6.2.tgz",
+      "integrity": "sha512-iAErsLxJ8C+S02QbLAwgSGSezLQK+XXRDt8IuFXFpwCNw2ECmzZSmjKcCaFVp5VRMk+WAvz6h6jokzEzBFZEuA==",
       "dev": true,
       "dependencies": {
-        "@jest/expect-utils": "^29.6.1",
+        "@jest/expect-utils": "^29.6.2",
         "@types/node": "*",
         "jest-get-type": "^29.4.3",
-        "jest-matcher-utils": "^29.6.1",
-        "jest-message-util": "^29.6.1",
-        "jest-util": "^29.6.1"
+        "jest-matcher-utils": "^29.6.2",
+        "jest-message-util": "^29.6.2",
+        "jest-util": "^29.6.2"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -2569,9 +2650,9 @@
       "dev": true
     },
     "node_modules/fast-glob": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.0.tgz",
-      "integrity": "sha512-ChDuvbOypPuNjO8yIDf36x7BlZX1smcUMTTcyoIjycexOxd6DFsKsg21qVBzEmr3G7fUKIRy2/psii+CIUt7FA==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
       "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -2781,9 +2862,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "13.20.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
-      "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
+      "version": "13.21.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.21.0.tgz",
+      "integrity": "sha512-ybyme3s4yy/t/3s35bewwXKOf7cvzfreG2lH0lZl0JB7I4GxRP2ghxOK/Nb9EkRXdbBXZLfq/p/0W2JUONB/Gg==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -2958,9 +3039,9 @@
       "dev": true
     },
     "node_modules/is-core-module": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.1.tgz",
-      "integrity": "sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.0.tgz",
+      "integrity": "sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==",
       "dev": true,
       "dependencies": {
         "has": "^1.0.3"
@@ -3087,17 +3168,17 @@
       }
     },
     "node_modules/istanbul-lib-report": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
-      "integrity": "sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
       "dev": true,
       "dependencies": {
         "istanbul-lib-coverage": "^3.0.0",
-        "make-dir": "^3.0.0",
+        "make-dir": "^4.0.0",
         "supports-color": "^7.1.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
       }
     },
     "node_modules/istanbul-lib-source-maps": {
@@ -3115,9 +3196,9 @@
       }
     },
     "node_modules/istanbul-reports": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.5.tgz",
-      "integrity": "sha512-nUsEMa9pBt/NOHqbcbeJEgqIlY/K7rVWUX6Lql2orY5e9roQOthbR3vtY4zzf2orPELg80fnxxk9zUyPlgwD1w==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.6.tgz",
+      "integrity": "sha512-TLgnMkKg3iTDsQ9PbPTdpfAK2DzjF9mqUG7RMgcQl8oFjad8ob4laGxv5XV5U9MAfx8D6tSJiUyuAwzLicaxlg==",
       "dev": true,
       "dependencies": {
         "html-escaper": "^2.0.0",
@@ -3128,15 +3209,15 @@
       }
     },
     "node_modules/jest": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-29.6.1.tgz",
-      "integrity": "sha512-Nirw5B4nn69rVUZtemCQhwxOBhm0nsp3hmtF4rzCeWD7BkjAXRIji7xWQfnTNbz9g0aVsBX6aZK3n+23LM6uDw==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-29.6.2.tgz",
+      "integrity": "sha512-8eQg2mqFbaP7CwfsTpCxQ+sHzw1WuNWL5UUvjnWP4hx2riGz9fPSzYOaU5q8/GqWn1TfgZIVTqYJygbGbWAANg==",
       "dev": true,
       "dependencies": {
-        "@jest/core": "^29.6.1",
+        "@jest/core": "^29.6.2",
         "@jest/types": "^29.6.1",
         "import-local": "^3.0.2",
-        "jest-cli": "^29.6.1"
+        "jest-cli": "^29.6.2"
       },
       "bin": {
         "jest": "bin/jest.js"
@@ -3167,28 +3248,28 @@
       }
     },
     "node_modules/jest-circus": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.6.1.tgz",
-      "integrity": "sha512-tPbYLEiBU4MYAL2XoZme/bgfUeotpDBd81lgHLCbDZZFaGmECk0b+/xejPFtmiBP87GgP/y4jplcRpbH+fgCzQ==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.6.2.tgz",
+      "integrity": "sha512-G9mN+KOYIUe2sB9kpJkO9Bk18J4dTDArNFPwoZ7WKHKel55eKIS/u2bLthxgojwlf9NLCVQfgzM/WsOVvoC6Fw==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "^29.6.1",
-        "@jest/expect": "^29.6.1",
-        "@jest/test-result": "^29.6.1",
+        "@jest/environment": "^29.6.2",
+        "@jest/expect": "^29.6.2",
+        "@jest/test-result": "^29.6.2",
         "@jest/types": "^29.6.1",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "co": "^4.6.0",
-        "dedent": "^0.7.0",
+        "dedent": "^1.0.0",
         "is-generator-fn": "^2.0.0",
-        "jest-each": "^29.6.1",
-        "jest-matcher-utils": "^29.6.1",
-        "jest-message-util": "^29.6.1",
-        "jest-runtime": "^29.6.1",
-        "jest-snapshot": "^29.6.1",
-        "jest-util": "^29.6.1",
+        "jest-each": "^29.6.2",
+        "jest-matcher-utils": "^29.6.2",
+        "jest-message-util": "^29.6.2",
+        "jest-runtime": "^29.6.2",
+        "jest-snapshot": "^29.6.2",
+        "jest-util": "^29.6.2",
         "p-limit": "^3.1.0",
-        "pretty-format": "^29.6.1",
+        "pretty-format": "^29.6.2",
         "pure-rand": "^6.0.0",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
@@ -3198,21 +3279,21 @@
       }
     },
     "node_modules/jest-cli": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.6.1.tgz",
-      "integrity": "sha512-607dSgTA4ODIN6go9w6xY3EYkyPFGicx51a69H7yfvt7lN53xNswEVLovq+E77VsTRi5fWprLH0yl4DJgE8Ing==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.6.2.tgz",
+      "integrity": "sha512-TT6O247v6dCEX2UGHGyflMpxhnrL0DNqP2fRTKYm3nJJpCTfXX3GCMQPGFjXDoj0i5/Blp3jriKXFgdfmbYB6Q==",
       "dev": true,
       "dependencies": {
-        "@jest/core": "^29.6.1",
-        "@jest/test-result": "^29.6.1",
+        "@jest/core": "^29.6.2",
+        "@jest/test-result": "^29.6.2",
         "@jest/types": "^29.6.1",
         "chalk": "^4.0.0",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.9",
         "import-local": "^3.0.2",
-        "jest-config": "^29.6.1",
-        "jest-util": "^29.6.1",
-        "jest-validate": "^29.6.1",
+        "jest-config": "^29.6.2",
+        "jest-util": "^29.6.2",
+        "jest-validate": "^29.6.2",
         "prompts": "^2.0.1",
         "yargs": "^17.3.1"
       },
@@ -3232,31 +3313,31 @@
       }
     },
     "node_modules/jest-config": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.6.1.tgz",
-      "integrity": "sha512-XdjYV2fy2xYixUiV2Wc54t3Z4oxYPAELUzWnV6+mcbq0rh742X2p52pii5A3oeRzYjLnQxCsZmp0qpI6klE2cQ==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.6.2.tgz",
+      "integrity": "sha512-VxwFOC8gkiJbuodG9CPtMRjBUNZEHxwfQXmIudSTzFWxaci3Qub1ddTRbFNQlD/zUeaifLndh/eDccFX4wCMQw==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
-        "@jest/test-sequencer": "^29.6.1",
+        "@jest/test-sequencer": "^29.6.2",
         "@jest/types": "^29.6.1",
-        "babel-jest": "^29.6.1",
+        "babel-jest": "^29.6.2",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
         "deepmerge": "^4.2.2",
         "glob": "^7.1.3",
         "graceful-fs": "^4.2.9",
-        "jest-circus": "^29.6.1",
-        "jest-environment-node": "^29.6.1",
+        "jest-circus": "^29.6.2",
+        "jest-environment-node": "^29.6.2",
         "jest-get-type": "^29.4.3",
         "jest-regex-util": "^29.4.3",
-        "jest-resolve": "^29.6.1",
-        "jest-runner": "^29.6.1",
-        "jest-util": "^29.6.1",
-        "jest-validate": "^29.6.1",
+        "jest-resolve": "^29.6.2",
+        "jest-runner": "^29.6.2",
+        "jest-util": "^29.6.2",
+        "jest-validate": "^29.6.2",
         "micromatch": "^4.0.4",
         "parse-json": "^5.2.0",
-        "pretty-format": "^29.6.1",
+        "pretty-format": "^29.6.2",
         "slash": "^3.0.0",
         "strip-json-comments": "^3.1.1"
       },
@@ -3277,15 +3358,15 @@
       }
     },
     "node_modules/jest-diff": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.6.1.tgz",
-      "integrity": "sha512-FsNCvinvl8oVxpNLttNQX7FAq7vR+gMDGj90tiP7siWw1UdakWUGqrylpsYrpvj908IYckm5Y0Q7azNAozU1Kg==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.6.2.tgz",
+      "integrity": "sha512-t+ST7CB9GX5F2xKwhwCf0TAR17uNDiaPTZnVymP9lw0lssa9vG+AFyDZoeIHStU3WowFFwT+ky+er0WVl2yGhA==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
         "diff-sequences": "^29.4.3",
         "jest-get-type": "^29.4.3",
-        "pretty-format": "^29.6.1"
+        "pretty-format": "^29.6.2"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -3304,33 +3385,33 @@
       }
     },
     "node_modules/jest-each": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.6.1.tgz",
-      "integrity": "sha512-n5eoj5eiTHpKQCAVcNTT7DRqeUmJ01hsAL0Q1SMiBHcBcvTKDELixQOGMCpqhbIuTcfC4kMfSnpmDqRgRJcLNQ==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.6.2.tgz",
+      "integrity": "sha512-MsrsqA0Ia99cIpABBc3izS1ZYoYfhIy0NNWqPSE0YXbQjwchyt6B1HD2khzyPe1WiJA7hbxXy77ZoUQxn8UlSw==",
       "dev": true,
       "dependencies": {
         "@jest/types": "^29.6.1",
         "chalk": "^4.0.0",
         "jest-get-type": "^29.4.3",
-        "jest-util": "^29.6.1",
-        "pretty-format": "^29.6.1"
+        "jest-util": "^29.6.2",
+        "pretty-format": "^29.6.2"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-environment-node": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.6.1.tgz",
-      "integrity": "sha512-ZNIfAiE+foBog24W+2caIldl4Irh8Lx1PUhg/GZ0odM1d/h2qORAsejiFc7zb+SEmYPn1yDZzEDSU5PmDkmVLQ==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.6.2.tgz",
+      "integrity": "sha512-YGdFeZ3T9a+/612c5mTQIllvWkddPbYcN2v95ZH24oWMbGA4GGS2XdIF92QMhUhvrjjuQWYgUGW2zawOyH63MQ==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "^29.6.1",
-        "@jest/fake-timers": "^29.6.1",
+        "@jest/environment": "^29.6.2",
+        "@jest/fake-timers": "^29.6.2",
         "@jest/types": "^29.6.1",
         "@types/node": "*",
-        "jest-mock": "^29.6.1",
-        "jest-util": "^29.6.1"
+        "jest-mock": "^29.6.2",
+        "jest-util": "^29.6.2"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -3346,9 +3427,9 @@
       }
     },
     "node_modules/jest-haste-map": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.6.1.tgz",
-      "integrity": "sha512-0m7f9PZXxOCk1gRACiVgX85knUKPKLPg4oRCjLoqIm9brTHXaorMA0JpmtmVkQiT8nmXyIVoZd/nnH1cfC33ig==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.6.2.tgz",
+      "integrity": "sha512-+51XleTDAAysvU8rT6AnS1ZJ+WHVNqhj1k6nTvN2PYP+HjU3kqlaKQ1Lnw3NYW3bm2r8vq82X0Z1nDDHZMzHVA==",
       "dev": true,
       "dependencies": {
         "@jest/types": "^29.6.1",
@@ -3358,8 +3439,8 @@
         "fb-watchman": "^2.0.0",
         "graceful-fs": "^4.2.9",
         "jest-regex-util": "^29.4.3",
-        "jest-util": "^29.6.1",
-        "jest-worker": "^29.6.1",
+        "jest-util": "^29.6.2",
+        "jest-worker": "^29.6.2",
         "micromatch": "^4.0.4",
         "walker": "^1.0.8"
       },
@@ -3371,37 +3452,37 @@
       }
     },
     "node_modules/jest-leak-detector": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.6.1.tgz",
-      "integrity": "sha512-OrxMNyZirpOEwkF3UHnIkAiZbtkBWiye+hhBweCHkVbCgyEy71Mwbb5zgeTNYWJBi1qgDVfPC1IwO9dVEeTLwQ==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.6.2.tgz",
+      "integrity": "sha512-aNqYhfp5uYEO3tdWMb2bfWv6f0b4I0LOxVRpnRLAeque2uqOVVMLh6khnTcE2qJ5wAKop0HcreM1btoysD6bPQ==",
       "dev": true,
       "dependencies": {
         "jest-get-type": "^29.4.3",
-        "pretty-format": "^29.6.1"
+        "pretty-format": "^29.6.2"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-matcher-utils": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.6.1.tgz",
-      "integrity": "sha512-SLaztw9d2mfQQKHmJXKM0HCbl2PPVld/t9Xa6P9sgiExijviSp7TnZZpw2Fpt+OI3nwUO/slJbOfzfUMKKC5QA==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.6.2.tgz",
+      "integrity": "sha512-4LiAk3hSSobtomeIAzFTe+N8kL6z0JtF3n6I4fg29iIW7tt99R7ZcIFW34QkX+DuVrf+CUe6wuVOpm7ZKFJzZQ==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
-        "jest-diff": "^29.6.1",
+        "jest-diff": "^29.6.2",
         "jest-get-type": "^29.4.3",
-        "pretty-format": "^29.6.1"
+        "pretty-format": "^29.6.2"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-message-util": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.6.1.tgz",
-      "integrity": "sha512-KoAW2zAmNSd3Gk88uJ56qXUWbFk787QKmjjJVOjtGFmmGSZgDBrlIL4AfQw1xyMYPNVD7dNInfIbur9B2rd/wQ==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.6.2.tgz",
+      "integrity": "sha512-vnIGYEjoPSuRqV8W9t+Wow95SDp6KPX2Uf7EoeG9G99J2OVh7OSwpS4B6J0NfpEIpfkBNHlBZpA2rblEuEFhZQ==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
@@ -3410,7 +3491,7 @@
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
         "micromatch": "^4.0.4",
-        "pretty-format": "^29.6.1",
+        "pretty-format": "^29.6.2",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
       },
@@ -3419,14 +3500,14 @@
       }
     },
     "node_modules/jest-mock": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.6.1.tgz",
-      "integrity": "sha512-brovyV9HBkjXAEdRooaTQK42n8usKoSRR3gihzUpYeV/vwqgSoNfrksO7UfSACnPmxasO/8TmHM3w9Hp3G1dgw==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.6.2.tgz",
+      "integrity": "sha512-hoSv3lb3byzdKfwqCuT6uTscan471GUECqgNYykg6ob0yiAw3zYc7OrPnI9Qv8Wwoa4lC7AZ9hyS4AiIx5U2zg==",
       "dev": true,
       "dependencies": {
         "@jest/types": "^29.6.1",
         "@types/node": "*",
-        "jest-util": "^29.6.1"
+        "jest-util": "^29.6.2"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -3459,17 +3540,17 @@
       }
     },
     "node_modules/jest-resolve": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.6.1.tgz",
-      "integrity": "sha512-AeRkyS8g37UyJiP9w3mmI/VXU/q8l/IH52vj/cDAyScDcemRbSBhfX/NMYIGilQgSVwsjxrCHf3XJu4f+lxCMg==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.6.2.tgz",
+      "integrity": "sha512-G/iQUvZWI5e3SMFssc4ug4dH0aZiZpsDq9o1PtXTV1210Ztyb2+w+ZgQkB3iOiC5SmAEzJBOHWz6Hvrd+QnNPw==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.6.1",
+        "jest-haste-map": "^29.6.2",
         "jest-pnp-resolver": "^1.2.2",
-        "jest-util": "^29.6.1",
-        "jest-validate": "^29.6.1",
+        "jest-util": "^29.6.2",
+        "jest-validate": "^29.6.2",
         "resolve": "^1.20.0",
         "resolve.exports": "^2.0.0",
         "slash": "^3.0.0"
@@ -3479,43 +3560,43 @@
       }
     },
     "node_modules/jest-resolve-dependencies": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.6.1.tgz",
-      "integrity": "sha512-BbFvxLXtcldaFOhNMXmHRWx1nXQO5LoXiKSGQcA1LxxirYceZT6ch8KTE1bK3X31TNG/JbkI7OkS/ABexVahiw==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.6.2.tgz",
+      "integrity": "sha512-LGqjDWxg2fuQQm7ypDxduLu/m4+4Lb4gczc13v51VMZbVP5tSBILqVx8qfWcsdP8f0G7aIqByIALDB0R93yL+w==",
       "dev": true,
       "dependencies": {
         "jest-regex-util": "^29.4.3",
-        "jest-snapshot": "^29.6.1"
+        "jest-snapshot": "^29.6.2"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-runner": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.6.1.tgz",
-      "integrity": "sha512-tw0wb2Q9yhjAQ2w8rHRDxteryyIck7gIzQE4Reu3JuOBpGp96xWgF0nY8MDdejzrLCZKDcp8JlZrBN/EtkQvPQ==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.6.2.tgz",
+      "integrity": "sha512-wXOT/a0EspYgfMiYHxwGLPCZfC0c38MivAlb2lMEAlwHINKemrttu1uSbcGbfDV31sFaPWnWJPmb2qXM8pqZ4w==",
       "dev": true,
       "dependencies": {
-        "@jest/console": "^29.6.1",
-        "@jest/environment": "^29.6.1",
-        "@jest/test-result": "^29.6.1",
-        "@jest/transform": "^29.6.1",
+        "@jest/console": "^29.6.2",
+        "@jest/environment": "^29.6.2",
+        "@jest/test-result": "^29.6.2",
+        "@jest/transform": "^29.6.2",
         "@jest/types": "^29.6.1",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "emittery": "^0.13.1",
         "graceful-fs": "^4.2.9",
         "jest-docblock": "^29.4.3",
-        "jest-environment-node": "^29.6.1",
-        "jest-haste-map": "^29.6.1",
-        "jest-leak-detector": "^29.6.1",
-        "jest-message-util": "^29.6.1",
-        "jest-resolve": "^29.6.1",
-        "jest-runtime": "^29.6.1",
-        "jest-util": "^29.6.1",
-        "jest-watcher": "^29.6.1",
-        "jest-worker": "^29.6.1",
+        "jest-environment-node": "^29.6.2",
+        "jest-haste-map": "^29.6.2",
+        "jest-leak-detector": "^29.6.2",
+        "jest-message-util": "^29.6.2",
+        "jest-resolve": "^29.6.2",
+        "jest-runtime": "^29.6.2",
+        "jest-util": "^29.6.2",
+        "jest-watcher": "^29.6.2",
+        "jest-worker": "^29.6.2",
         "p-limit": "^3.1.0",
         "source-map-support": "0.5.13"
       },
@@ -3524,17 +3605,17 @@
       }
     },
     "node_modules/jest-runtime": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.6.1.tgz",
-      "integrity": "sha512-D6/AYOA+Lhs5e5il8+5pSLemjtJezUr+8zx+Sn8xlmOux3XOqx4d8l/2udBea8CRPqqrzhsKUsN/gBDE/IcaPQ==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.6.2.tgz",
+      "integrity": "sha512-2X9dqK768KufGJyIeLmIzToDmsN0m7Iek8QNxRSI/2+iPFYHF0jTwlO3ftn7gdKd98G/VQw9XJCk77rbTGZnJg==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "^29.6.1",
-        "@jest/fake-timers": "^29.6.1",
-        "@jest/globals": "^29.6.1",
+        "@jest/environment": "^29.6.2",
+        "@jest/fake-timers": "^29.6.2",
+        "@jest/globals": "^29.6.2",
         "@jest/source-map": "^29.6.0",
-        "@jest/test-result": "^29.6.1",
-        "@jest/transform": "^29.6.1",
+        "@jest/test-result": "^29.6.2",
+        "@jest/transform": "^29.6.2",
         "@jest/types": "^29.6.1",
         "@types/node": "*",
         "chalk": "^4.0.0",
@@ -3542,13 +3623,13 @@
         "collect-v8-coverage": "^1.0.0",
         "glob": "^7.1.3",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.6.1",
-        "jest-message-util": "^29.6.1",
-        "jest-mock": "^29.6.1",
+        "jest-haste-map": "^29.6.2",
+        "jest-message-util": "^29.6.2",
+        "jest-mock": "^29.6.2",
         "jest-regex-util": "^29.4.3",
-        "jest-resolve": "^29.6.1",
-        "jest-snapshot": "^29.6.1",
-        "jest-util": "^29.6.1",
+        "jest-resolve": "^29.6.2",
+        "jest-snapshot": "^29.6.2",
+        "jest-util": "^29.6.2",
         "slash": "^3.0.0",
         "strip-bom": "^4.0.0"
       },
@@ -3557,9 +3638,9 @@
       }
     },
     "node_modules/jest-snapshot": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.6.1.tgz",
-      "integrity": "sha512-G4UQE1QQ6OaCgfY+A0uR1W2AY0tGXUPQpoUClhWHq1Xdnx1H6JOrC2nH5lqnOEqaDgbHFgIwZ7bNq24HpB180A==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.6.2.tgz",
+      "integrity": "sha512-1OdjqvqmRdGNvWXr/YZHuyhh5DeaLp1p/F8Tht/MrMw4Kr1Uu/j4lRG+iKl1DAqUJDWxtQBMk41Lnf/JETYBRA==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
@@ -3567,21 +3648,20 @@
         "@babel/plugin-syntax-jsx": "^7.7.2",
         "@babel/plugin-syntax-typescript": "^7.7.2",
         "@babel/types": "^7.3.3",
-        "@jest/expect-utils": "^29.6.1",
-        "@jest/transform": "^29.6.1",
+        "@jest/expect-utils": "^29.6.2",
+        "@jest/transform": "^29.6.2",
         "@jest/types": "^29.6.1",
-        "@types/prettier": "^2.1.5",
         "babel-preset-current-node-syntax": "^1.0.0",
         "chalk": "^4.0.0",
-        "expect": "^29.6.1",
+        "expect": "^29.6.2",
         "graceful-fs": "^4.2.9",
-        "jest-diff": "^29.6.1",
+        "jest-diff": "^29.6.2",
         "jest-get-type": "^29.4.3",
-        "jest-matcher-utils": "^29.6.1",
-        "jest-message-util": "^29.6.1",
-        "jest-util": "^29.6.1",
+        "jest-matcher-utils": "^29.6.2",
+        "jest-message-util": "^29.6.2",
+        "jest-util": "^29.6.2",
         "natural-compare": "^1.4.0",
-        "pretty-format": "^29.6.1",
+        "pretty-format": "^29.6.2",
         "semver": "^7.5.3"
       },
       "engines": {
@@ -3589,9 +3669,9 @@
       }
     },
     "node_modules/jest-util": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.6.1.tgz",
-      "integrity": "sha512-NRFCcjc+/uO3ijUVyNOQJluf8PtGCe/W6cix36+M3cTFgiYqFOOW5MgN4JOOcvbUhcKTYVd1CvHz/LWi8d16Mg==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.6.2.tgz",
+      "integrity": "sha512-3eX1qb6L88lJNCFlEADKOkjpXJQyZRiavX1INZ4tRnrBVr2COd3RgcTLyUiEXMNBlDU/cgYq6taUS0fExrWW4w==",
       "dev": true,
       "dependencies": {
         "@jest/types": "^29.6.1",
@@ -3606,9 +3686,9 @@
       }
     },
     "node_modules/jest-validate": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.6.1.tgz",
-      "integrity": "sha512-r3Ds69/0KCN4vx4sYAbGL1EVpZ7MSS0vLmd3gV78O+NAx3PDQQukRU5hNHPXlyqCgFY8XUk7EuTMLugh0KzahA==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.6.2.tgz",
+      "integrity": "sha512-vGz0yMN5fUFRRbpJDPwxMpgSXW1LDKROHfBopAvDcmD6s+B/s8WJrwi+4bfH4SdInBA5C3P3BI19dBtKzx1Arg==",
       "dev": true,
       "dependencies": {
         "@jest/types": "^29.6.1",
@@ -3616,7 +3696,7 @@
         "chalk": "^4.0.0",
         "jest-get-type": "^29.4.3",
         "leven": "^3.1.0",
-        "pretty-format": "^29.6.1"
+        "pretty-format": "^29.6.2"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -3635,18 +3715,18 @@
       }
     },
     "node_modules/jest-watcher": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.6.1.tgz",
-      "integrity": "sha512-d4wpjWTS7HEZPaaj8m36QiaP856JthRZkrgcIY/7ISoUWPIillrXM23WPboZVLbiwZBt4/qn2Jke84Sla6JhFA==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.6.2.tgz",
+      "integrity": "sha512-GZitlqkMkhkefjfN/p3SJjrDaxPflqxEAv3/ik10OirZqJGYH5rPiIsgVcfof0Tdqg3shQGdEIxDBx+B4tuLzA==",
       "dev": true,
       "dependencies": {
-        "@jest/test-result": "^29.6.1",
+        "@jest/test-result": "^29.6.2",
         "@jest/types": "^29.6.1",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.0.0",
         "emittery": "^0.13.1",
-        "jest-util": "^29.6.1",
+        "jest-util": "^29.6.2",
         "string-length": "^4.0.1"
       },
       "engines": {
@@ -3654,13 +3734,13 @@
       }
     },
     "node_modules/jest-worker": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.6.1.tgz",
-      "integrity": "sha512-U+Wrbca7S8ZAxAe9L6nb6g8kPdia5hj32Puu5iOqBCMTMWFHXuK6dOV2IFrpedbTV8fjMFLdWNttQTBL6u2MRA==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.6.2.tgz",
+      "integrity": "sha512-l3ccBOabTdkng8I/ORCkADz4eSMKejTYv1vB/Z83UiubqhC1oQ5Li6dWCyqOIvSifGjUBxuvxvlm6KGK2DtuAQ==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
-        "jest-util": "^29.6.1",
+        "jest-util": "^29.6.2",
         "merge-stream": "^2.0.0",
         "supports-color": "^8.0.0"
       },
@@ -3817,27 +3897,18 @@
       }
     },
     "node_modules/make-dir": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
       "dev": true,
       "dependencies": {
-        "semver": "^6.0.0"
+        "semver": "^7.5.3"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/make-dir/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
       }
     },
     "node_modules/make-error": {
@@ -4335,9 +4406,9 @@
       }
     },
     "node_modules/pretty-format": {
-      "version": "29.6.1",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.6.1.tgz",
-      "integrity": "sha512-7jRj+yXO0W7e4/tSJKoR7HRIHLPPjtNaUGG2xxKQnGvPNRkgWcQ0AZX6P4KBRJN4FcTBWb3sa7DVUJmocYuoog==",
+      "version": "29.6.2",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.6.2.tgz",
+      "integrity": "sha512-1q0oC8eRveTg5nnBEWMXAU2qpv65Gnuf2eCQzSjxpWFkPaPARwqZZDGuNE0zPAZfTCHzIk3A8dIjwlQKKLphyg==",
       "dev": true,
       "dependencies": {
         "@jest/schemas": "^29.6.0",
@@ -4501,12 +4572,12 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
-      "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
+      "version": "1.22.4",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.4.tgz",
+      "integrity": "sha512-PXNdCiPqDqeUou+w1C2eTQbNfxKSuMxqTCuvlmmMsk1NWHL5fRrhY6Pl0qEYYc6+QqGClco1Qj8XnjPego4wfg==",
       "dev": true,
       "dependencies": {
-        "is-core-module": "^2.11.0",
+        "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -751,9 +751,9 @@
       "dev": true
     },
     "node_modules/@dev-build-deploy/commit-it": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@dev-build-deploy/commit-it/-/commit-it-0.4.2.tgz",
-      "integrity": "sha512-s1Xw5IsGQBBdd1hcxE8WnSGSl32b9mEoGHtlOBCovfrD/8O1TRIutEFg27lbnNhBBUL2GXtQjqmYx5R6uS4Zjg==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@dev-build-deploy/commit-it/-/commit-it-0.4.3.tgz",
+      "integrity": "sha512-mdji8xHv8Flb7cH5m4gVOU+hqAgrFxnZfqDjperAganLSco8Zcrnr3neAaOoXw5kfCDpP9aXpNpRXXwKQBdapw==",
       "dependencies": {
         "@dev-build-deploy/diagnose-it": "<1.0.0"
       }

--- a/test/versioning.test.ts
+++ b/test/versioning.test.ts
@@ -126,9 +126,9 @@ describe("Determine bump type (default branch)", () => {
 
   test("Added Feature", () => {
     const commits: IConventionalCommit[] = [
-      { hash: "0a0b0c0d", subject: "feat: add new feature", type: "feat", description: "add new feature" },
+      { hash: "0a0b0c0d", subject: "feat(login): add support google oauth (#12)", type: "feat", scope: "login", description: "add support google oauth (#12)" },
       { hash: "0a0b0c0d", subject: "fix: prevent bug", type: "fix", description: "prevent bug" },
-      { hash: "0a0b0c0d", subject: "chore: non breaking change", type: "chore", description: "non breaking change" },
+      { hash: "0a0b0c0d", subject: "chore: non breaking change", type: "chore", description: "non breaking change" }
     ];
     const semver = new versioning.SemVerScheme();
     const calver = new versioning.CalVerScheme();
@@ -208,7 +208,7 @@ describe("Determine bump type (release branch)", () => {
 
   test("Added Feature", () => {
     const commits: IConventionalCommit[] = [
-      { hash: "0a0b0c0d", subject: "feat: add new feature", type: "feat", description: "add new feature" },
+      { hash: "0a0b0c0d", subject: "feat(login): add support google oauth (#12)", type: "feat", scope: "login", description: "add support google oauth (#12)" },
       { hash: "0a0b0c0d", subject: "fix: prevent bug", type: "fix", description: "prevent bug" },
       { hash: "0a0b0c0d", subject: "chore: non breaking change", type: "chore", description: "non breaking change" },
     ];


### PR DESCRIPTION
The dependency `@dev-build-deploy/commit-it` has been updated to correctly handle commit message subjects containing both a scope and multiple closing brackets.

This will ensure that the following commit messages are correctly identified as Conventional Commits:
```
feat(login): google auth (#1)
ci(action): clean-up workflows (and more)
```