### PR TITLE
fix: discard BREAKING CHANGE commits with incorrect capitalization

### DIFF
--- a/lib/get/index.js
+++ b/lib/get/index.js
@@ -2093,9 +2093,9 @@ function isLoopbackAddress(host) {
 "use strict";
 
 /*
-SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
-SPDX-License-Identifier: MIT
-*/
+ * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
+ */
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     var desc = Object.getOwnPropertyDescriptor(m, k);
@@ -2120,8 +2120,75 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getCommit = exports.isConventionalCommit = exports.parseCommitMessage = void 0;
+exports.parseCommitMessage = exports.getFooterElementsFromParagraph = exports.Commit = void 0;
 const git = __importStar(__nccwpck_require__(8433));
+const TRAILER_REGEX = /^((BREAKING CHANGE:)|([\w-]+(:| #))|([ \t]+)\w*)/i;
+/**
+ * Git Commit
+ * @class Commit
+ * @member author The commit author and date
+ * @member commiter The commit commiter and date
+ * @member hash The commit hash
+ * @member subject The commit subject
+ * @member body The commit body
+ * @member footer The commit footer
+ * @member raw The commit message
+ */
+class Commit {
+    _commit;
+    constructor(commit) {
+        this._commit = commit;
+    }
+    /**
+     * Retrieves the commit information from git using the provided hash
+     * @param props The commit hash and root path
+     * @returns The commit object
+     */
+    static fromHash(props) {
+        const commit = git.getCommitFromHash(props.hash, props.rootPath ?? process.cwd());
+        return new Commit(commit);
+    }
+    /**
+     * Creates a Commit object from the provided string
+     * @param props The commit hash, author, committer and message
+     * @returns The commit object
+     */
+    static fromString(props) {
+        const commit = {
+            hash: props.hash,
+            ...parseCommitMessage(props.message),
+            author: props.author,
+            committer: props.committer,
+            raw: props.message,
+        };
+        return new Commit(commit);
+    }
+    get author() {
+        return this._commit.author;
+    }
+    get committer() {
+        return this._commit.committer;
+    }
+    get hash() {
+        return this._commit.hash;
+    }
+    get subject() {
+        return this._commit.subject;
+    }
+    get body() {
+        return this._commit.body;
+    }
+    get footer() {
+        return this._commit.footer;
+    }
+    get raw() {
+        return this._commit.raw;
+    }
+    toJSON() {
+        return this._commit;
+    }
+}
+exports.Commit = Commit;
 /**
  * Returns a dictionary containing key-value pairs extracted from the footer of the provided commit message.
  * The key must either be:
@@ -2131,13 +2198,15 @@ const git = __importStar(__nccwpck_require__(8433));
  * The value is either:
  * - the remainder of the line
  * - the remainder of the line + anything that follows on the next lines which is indented by at least one space
+ *
+ * @internal
  */
-function parseCommitFooter(footer) {
-    const footerLines = footer.split(/[\r\n]+/);
-    const result = {};
+function getFooterElementsFromParagraph(footer) {
+    const footerLines = footer.split(/\r?\n/);
+    const result = [];
     for (let lineNr = 0; lineNr < footerLines.length; lineNr++) {
         const line = footerLines[lineNr];
-        const match = /^((BREAKING CHANGE:)|([\w-]+(:| #))|([ \t]+)\w)/.exec(line);
+        const match = TRAILER_REGEX.exec(line);
         if (match === null)
             continue;
         let key = match[1].replace(/:$/, "");
@@ -2146,15 +2215,22 @@ function parseCommitFooter(footer) {
             key = match[1].substring(0, match[1].length - 2);
             value = `#${value}`;
         }
+        const matchLine = lineNr;
         // Check if the value continues on the next line
-        while (lineNr + 1 < footerLines.length && footerLines[lineNr + 1].startsWith(" ")) {
+        while (lineNr + 1 < footerLines.length &&
+            (/^\s/.test(footerLines[lineNr + 1]) || footerLines[lineNr + 1].length === 0)) {
             lineNr++;
             value += "\n" + footerLines[lineNr].trim();
         }
-        result[key] = value;
+        result.push({
+            lineNumber: matchLine + 1,
+            key,
+            value,
+        });
     }
     return Object.keys(result).length > 0 ? result : undefined;
 }
+exports.getFooterElementsFromParagraph = getFooterElementsFromParagraph;
 /**
  * Parses the provided commit message (full message, not just the subject) into
  * a Commit object.
@@ -2163,11 +2239,11 @@ function parseCommitFooter(footer) {
  * @internal
  */
 function parseCommitMessage(message) {
-    const isTrailerOnly = (message) => message.split(/[\r\n]+/).every(line => {
-        const match = /^((BREAKING CHANGE:)|([\w-]+(:| #))|([ \t]+)\w)/.exec(line);
+    const isTrailerOnly = (message) => message.split(/\r?\n/).every(line => {
+        const match = TRAILER_REGEX.exec(line);
         return match !== null;
     });
-    const paragraphs = message.split(/^[\r\n]+/m);
+    const paragraphs = message.split(/^\r?\n/m);
     let footer = undefined;
     let body = undefined;
     if (paragraphs.length > 1 && isTrailerOnly(paragraphs[paragraphs.length - 1])) {
@@ -2182,69 +2258,26 @@ function parseCommitMessage(message) {
     return {
         subject: paragraphs[0].trim(),
         body: body,
-        footer: parseCommitFooter(footer !== null && footer !== void 0 ? footer : ""),
+        footer: getFooterElementsFromParagraph(footer ?? "")?.reduce((acc, cur) => {
+            acc[cur.key] = cur.value;
+            return acc;
+        }, {}),
     };
 }
 exports.parseCommitMessage = parseCommitMessage;
-/**
- * Confirms whether the provided commit is a Conventional Commit
- * @param commit
- * @returns
- */
-function isConventionalCommit(commit) {
-    return "type" in commit;
-}
-exports.isConventionalCommit = isConventionalCommit;
-/**
- * Retrieves the commit message (from the indicated source) given the provided SHA hash
- * @param hash SHA of the commit
- * @param source The data source to retrieve the commit message from (git or github)
- * @param options The options to use when retrieving the commit message
- * @returns Commit object
- */
-function getCommit(options) {
-    var _a;
-    let commit;
-    // String data source
-    if ("message" in options) {
-        const stringOptions = options;
-        commit = {
-            hash: stringOptions.hash,
-            ...parseCommitMessage(stringOptions.message),
-            author: stringOptions.author,
-            committer: stringOptions.committer,
-        };
-        // GitHub data source
-    }
-    else if ("owner" in options) {
-        const githubOptions = options;
-        // TODO; implement basic GitHub client
-        commit = {
-            hash: githubOptions.hash,
-            subject: "",
-        };
-        // Git data source
-    }
-    else {
-        const gitOptions = options;
-        commit = git.getCommitFromHash(gitOptions.hash, (_a = gitOptions.rootPath) !== null && _a !== void 0 ? _a : process.cwd());
-    }
-    return commit;
-}
-exports.getCommit = getCommit;
 
 
 /***/ }),
 
-/***/ 8436:
+/***/ 1124:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
 
 /*
-SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
-SPDX-License-Identifier: MIT
-*/
+ * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
+ */
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     var desc = Object.getOwnPropertyDescriptor(m, k);
@@ -2268,101 +2301,166 @@ var __importStar = (this && this.__importStar) || function (mod) {
     __setModuleDefault(result, mod);
     return result;
 };
-var __importDefault = (this && this.__importDefault) || function (mod) {
-    return (mod && mod.__esModule) ? mod : { "default": mod };
-};
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getConventionalCommit = exports.isConventionalCommit = exports.ConventionalCommitError = void 0;
-const assert_1 = __importDefault(__nccwpck_require__(9491));
+exports.ConventionalCommit = void 0;
+const diagnose_it_1 = __nccwpck_require__(4657);
+const commit_1 = __nccwpck_require__(8065);
 const requirements = __importStar(__nccwpck_require__(4374));
 /**
- * Conventional Commit error
- * @class ConventionalCommitError
- * @extends Error
+ * Conventional Commit
+ * @class ConventionalCommit
+ * @member type Conventional Commit type
+ * @member scope Conventional Commit scope
+ * @member breaking Commit message has a Conventional Commit breaking change (!)
+ * @member description Conventional Commit description
+ * @member hash Commit hash
+ * @member subject Commit subject
+ * @member body Commit body
+ * @member footer Commit footer
+ * @member author Commit author and date
+ * @member committer Commit committer and date
+ * @member isValid Whether the Conventional Commit is valid
  * @member errors List of error messages
+ * @member warnings List of warning messages
  */
-class ConventionalCommitError extends Error {
-    constructor(errors) {
-        super("Commit is not compliant with the Conventional Commits specification.");
-        this.name = "ConventionalCommitError";
-        this.errors = errors;
+class ConventionalCommit {
+    _raw;
+    _errors = [];
+    _warnings = [];
+    constructor(raw, options) {
+        this._raw = raw;
+        this.validate(options);
+    }
+    /**
+     * Creates a new Conventional Commit object from the provided Commit.
+     * @param commit Commit to convert to a Conventional Commit
+     * @param options Options to use when validating the commit message
+     * @returns Conventional Commit
+     */
+    static fromCommit(commit, options) {
+        // Convert the Commit message to Raw Conventional Commit data
+        const rawConvCommit = createRawConventionalCommit(commit);
+        // Create a new Conventional Commit object
+        return new ConventionalCommit(rawConvCommit, options);
+    }
+    /**
+     * Creates a new Conventional Commit object from the provided string.
+     * @param props Hash, message and author/committer information
+     * @param options Options to use when validating the commit message
+     * @returns Conventional Commit
+     */
+    static fromString(props, options) {
+        return ConventionalCommit.fromCommit(commit_1.Commit.fromString(props), options);
+    }
+    /**
+     * Creates a new Conventional Commit object from the provided hash.
+     * @param props Hash and root path
+     * @param options Options to use when validating the commit message
+     * @returns Conventional Commit
+     */
+    static fromHash(props, options) {
+        return ConventionalCommit.fromCommit(commit_1.Commit.fromHash(props), options);
+    }
+    // Contributors
+    get author() {
+        return this._raw.commit.author;
+    }
+    get committer() {
+        return this._raw.commit.committer;
+    }
+    // Commit
+    get hash() {
+        return this._raw.commit.hash;
+    }
+    get subject() {
+        return this._raw.commit.subject;
+    }
+    get body() {
+        return this._raw.commit.body;
+    }
+    get footer() {
+        return this._raw.commit.footer;
+    }
+    // Conventional Commit
+    get type() {
+        return this._raw.type.value?.trimEnd();
+    }
+    get scope() {
+        // Removes the parenthesis from the scope
+        if (this._raw.scope.value !== undefined) {
+            return this._raw.scope.value.trimEnd().replace(/(\(|\))/g, "");
+        }
+        return this._raw.scope.value;
+    }
+    get description() {
+        return this._raw.description.value;
+    }
+    get breaking() {
+        return (this._raw.breaking.value?.trimEnd() === "!" ||
+            (this.footer !== undefined && ("BREAKING CHANGE" in this.footer || "BREAKING-CHANGE" in this.footer)));
+    }
+    // Raw
+    get raw() {
+        return this._raw.commit.raw;
+    }
+    // Validation
+    get isValid() {
+        return this._errors.length === 0;
+    }
+    get warnings() {
+        return this._warnings;
+    }
+    get errors() {
+        return this._errors;
+    }
+    toJSON() {
+        return {
+            hash: this.hash,
+            author: this.author,
+            committer: this.committer,
+            subject: this.subject,
+            body: this.body,
+            footer: this.footer,
+            type: this.type,
+            breaking: this.breaking,
+            description: this.description,
+            validation: {
+                isValid: this.isValid,
+                errors: this.errors,
+                warnings: this.warnings,
+            },
+        };
+    }
+    // Private validation function
+    validate(options) {
+        let results = [];
+        requirements.commitRules.forEach(rule => (results = [...results, ...rule.validate(this._raw, options)]));
+        this._errors = results.filter(r => r.level === diagnose_it_1.DiagnosticsLevelEnum.Error);
+        this._warnings = results.filter(r => r.level === diagnose_it_1.DiagnosticsLevelEnum.Warning);
     }
 }
-exports.ConventionalCommitError = ConventionalCommitError;
-/**
- * Returns whether the provided commit has a breaking change (either "!" in subject, or usage of /BREAKING[- ]CHANGE:/).
- * @param commit Commit to check
- * @returns Whether the provided commit has a breaking change
- */
-function hasBreakingChange(commit) {
-    return (commit.breaking.value === "!" ||
-        (commit.commit.footer !== undefined &&
-            ("BREAKING CHANGE" in commit.commit.footer || "BREAKING-CHANGE" in commit.commit.footer)));
-}
-/**
- * Validates a commit message against the Conventional Commit specification.
- * @param commit Commit message to validate against the Conventional Commit specification
- * @returns Conventional Commit mesage
- * @throws ExpressiveMessage[] if the commit message is not a valid Conventional Commit
- * @see https://www.conventionalcommits.org/en/v1.0.0/
- */
-function validate(commit, options) {
-    let errors = [];
-    requirements.commitRules.forEach(rule => (errors = [...errors, ...rule.validate(commit, options)]));
-    if (errors.length > 0)
-        throw new ConventionalCommitError(errors);
-    // Assume that we have a valid Conventional Commit message
-    (0, assert_1.default)(commit.type.value);
-    (0, assert_1.default)(commit.description.value);
-    return {
-        ...commit.commit,
-        type: commit.type.value,
-        scope: commit.scope.value,
-        breaking: hasBreakingChange(commit),
-        description: commit.description.value,
-    };
-}
-/**
- * Returns whether the provided commit is a Conventional Commit.
- * @param commit Commit to check
- * @returns Whether the provided commit is a Conventional Commit
- */
-function isConventionalCommit(commit) {
-    return "type" in commit;
-}
-exports.isConventionalCommit = isConventionalCommit;
-/**
- * Parses a Commit message into a Conventional Commit.
- * @param commit Commit message to parse
- * @param options Options to use when parsing the commit message
- * @throws ExpressiveMessage[] if the commit message is not a valid Conventional Commit
- * @returns Conventional Commit
- */
-function getConventionalCommit(commit, options) {
-    var _a, _b, _c, _d, _e;
+exports.ConventionalCommit = ConventionalCommit;
+function createRawConventionalCommit(commit) {
     const ConventionalCommitRegex = new RegExp(/^(?<type>[^(!:]*)(?<scope>\([^)]*\)\s*)?(?<breaking>!\s*)?(?<separator>:\s*)?(?<subject>.*)?$/);
-    const match = ConventionalCommitRegex.exec(commit.subject);
-    let conventionalCommit = {
+    const match = ConventionalCommitRegex.exec(commit.subject.split(/\r?\n/)[0]);
+    const conventionalCommit = {
         commit: commit,
-        type: { index: 1, value: (_a = match === null || match === void 0 ? void 0 : match.groups) === null || _a === void 0 ? void 0 : _a.type },
-        scope: { index: 1, value: (_b = match === null || match === void 0 ? void 0 : match.groups) === null || _b === void 0 ? void 0 : _b.scope },
-        breaking: { index: 1, value: (_c = match === null || match === void 0 ? void 0 : match.groups) === null || _c === void 0 ? void 0 : _c.breaking },
-        seperator: { index: 1, value: (_d = match === null || match === void 0 ? void 0 : match.groups) === null || _d === void 0 ? void 0 : _d.separator },
-        description: { index: 1, value: (_e = match === null || match === void 0 ? void 0 : match.groups) === null || _e === void 0 ? void 0 : _e.subject },
+        type: { index: 1, value: match?.groups?.type },
+        scope: { index: 1, value: match?.groups?.scope },
+        breaking: { index: 1, value: match?.groups?.breaking },
+        seperator: { index: 1, value: match?.groups?.separator },
+        description: { index: 1, value: match?.groups?.subject },
         body: { index: 1, value: commit.body },
     };
     function intializeIndices(commit) {
-        var _a, _b, _c, _d, _e, _f, _g, _h;
-        commit.scope.index = commit.type.index + ((_b = (_a = commit.type.value) === null || _a === void 0 ? void 0 : _a.length) !== null && _b !== void 0 ? _b : 0);
-        commit.breaking.index = commit.scope.index + ((_d = (_c = commit.scope.value) === null || _c === void 0 ? void 0 : _c.length) !== null && _d !== void 0 ? _d : 0);
-        commit.seperator.index = commit.breaking.index + ((_f = (_e = commit.breaking.value) === null || _e === void 0 ? void 0 : _e.length) !== null && _f !== void 0 ? _f : 0);
-        commit.description.index = commit.seperator.index + ((_h = (_g = commit.seperator.value) === null || _g === void 0 ? void 0 : _g.length) !== null && _h !== void 0 ? _h : 0);
+        commit.scope.index = commit.type.index + (commit.type.value?.length ?? 0);
+        commit.breaking.index = commit.scope.index + (commit.scope.value?.length ?? 0);
+        commit.seperator.index = commit.breaking.index + (commit.breaking.value?.length ?? 0);
+        commit.description.index = commit.seperator.index + (commit.seperator.value?.length ?? 0);
         return commit;
     }
-    conventionalCommit = intializeIndices(conventionalCommit);
-    return validate(conventionalCommit, options);
+    return intializeIndices(conventionalCommit);
 }
-exports.getConventionalCommit = getConventionalCommit;
 
 
 /***/ }),
@@ -2373,9 +2471,9 @@ exports.getConventionalCommit = getConventionalCommit;
 "use strict";
 
 /*
-SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
-SPDX-License-Identifier: MIT
-*/
+ * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
+ */
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     var desc = Object.getOwnPropertyDescriptor(m, k);
@@ -2455,15 +2553,17 @@ function getValueFromKey(commit, key) {
 function parseCommitMessage(commit, hash) {
     const author = extractNameAndDate(getValueFromKey(commit, "author"));
     const committer = extractNameAndDate(getValueFromKey(commit, "committer"));
+    const raw = commit
+        .split(/^[\r\n]+/m)
+        .splice(1)
+        .join("\n")
+        .trim();
     return {
+        raw,
         hash: hash,
         author: author,
         committer: committer,
-        ...ccommit.parseCommitMessage(commit
-            .split(/^[\r\n]+/m)
-            .splice(1)
-            .join("\n")
-            .trim()),
+        ...ccommit.parseCommitMessage(raw),
     };
 }
 /**
@@ -2605,17 +2705,15 @@ function readPackFile(path, index) {
 "use strict";
 
 /*
-SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
-SPDX-License-Identifier: MIT
-*/
+ * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
+ */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.ConventionalCommitError = exports.isConventionalCommit = exports.getConventionalCommit = exports.getCommit = void 0;
+exports.ConventionalCommit = exports.Commit = void 0;
 var commit_1 = __nccwpck_require__(8065);
-Object.defineProperty(exports, "getCommit", ({ enumerable: true, get: function () { return commit_1.getCommit; } }));
-var conventional_commit_1 = __nccwpck_require__(8436);
-Object.defineProperty(exports, "getConventionalCommit", ({ enumerable: true, get: function () { return conventional_commit_1.getConventionalCommit; } }));
-Object.defineProperty(exports, "isConventionalCommit", ({ enumerable: true, get: function () { return conventional_commit_1.isConventionalCommit; } }));
-Object.defineProperty(exports, "ConventionalCommitError", ({ enumerable: true, get: function () { return conventional_commit_1.ConventionalCommitError; } }));
+Object.defineProperty(exports, "Commit", ({ enumerable: true, get: function () { return commit_1.Commit; } }));
+var conventionalCommit_1 = __nccwpck_require__(1124);
+Object.defineProperty(exports, "ConventionalCommit", ({ enumerable: true, get: function () { return conventionalCommit_1.ConventionalCommit; } }));
 
 
 /***/ }),
@@ -2631,13 +2729,14 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.commitRules = void 0;
 /*
-SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
-
-SPDX-License-Identifier: MIT
-SPDX-License-Identifier: CC-BY-3.0
-*/
+ * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+ *
+ * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: CC-BY-3.0
+ */
 const diagnose_it_1 = __nccwpck_require__(4657);
 const chalk_1 = __importDefault(__nccwpck_require__(8818));
+const commit_1 = __nccwpck_require__(8065);
 function isNoun(str) {
     return !str.trim().includes(" ") && !/[^a-z]/i.test(str.trim());
 }
@@ -2650,29 +2749,30 @@ function highlightString(str, substring) {
     substring.forEach(sub => (result = result.replace(sub, `${chalk_1.default.cyan(sub)}`)));
     return result;
 }
-function createError(commit, description, highlight, type, whitespace = false) {
-    var _a, _b, _c, _d, _e, _f, _g, _h, _j;
+function createDiagnosticsMessage(commit, description, highlight, type, whitespace = false, level = diagnose_it_1.DiagnosticsLevelEnum.Error) {
     const element = commit[type];
     let hintIndex = element.index;
-    let hintLength = (_b = (_a = element.value) === null || _a === void 0 ? void 0 : _a.trimEnd().length) !== null && _b !== void 0 ? _b : 1;
+    let hintLength = element.value?.trimEnd().length ?? 1;
     if (whitespace) {
         let prevElement = undefined;
         for (const [_key, value] of Object.entries(commit)) {
-            if (value.index > ((_c = prevElement === null || prevElement === void 0 ? void 0 : prevElement.index) !== null && _c !== void 0 ? _c : 0) && value.index < element.index) {
+            if (value.index > (prevElement?.index ?? 0) && value.index < element.index) {
                 prevElement = value;
             }
         }
-        hintIndex = prevElement ? prevElement.index + ((_e = (_d = prevElement.value) === null || _d === void 0 ? void 0 : _d.trimEnd().length) !== null && _e !== void 0 ? _e : 1) : 1;
-        hintLength = ((_g = (_f = prevElement === null || prevElement === void 0 ? void 0 : prevElement.value) === null || _f === void 0 ? void 0 : _f.length) !== null && _g !== void 0 ? _g : 1) - ((_j = (_h = prevElement === null || prevElement === void 0 ? void 0 : prevElement.value) === null || _h === void 0 ? void 0 : _h.trimEnd().length) !== null && _j !== void 0 ? _j : 1);
+        hintIndex = prevElement ? prevElement.index + (prevElement.value?.trimEnd().length ?? 1) : 1;
+        hintLength = (prevElement?.value?.length ?? 1) - (prevElement?.value?.trimEnd().length ?? 1);
     }
-    return diagnose_it_1.DiagnosticsMessage.createError(commit.commit.hash, {
-        text: highlightString(description, highlight),
-        linenumber: 1,
-        column: hintIndex,
+    return new diagnose_it_1.DiagnosticsMessage({
+        file: commit.commit.hash,
+        level,
+        message: {
+            text: highlightString(description, highlight),
+            linenumber: 1,
+            column: hintIndex,
+        },
     })
-        .setContext(1, commit.commit.body !== undefined && commit.commit.body.split("\n").length >= 1
-        ? [commit.commit.subject, "", ...commit.commit.body.split("\n")]
-        : [commit.commit.subject])
+        .setContext(1, commit.commit.subject.split(/\r?\n/)[0])
         .addFixitHint(diagnose_it_1.FixItHint.create({ index: hintIndex, length: hintLength === 0 ? 1 : hintLength }));
 }
 /**
@@ -2680,10 +2780,8 @@ function createError(commit, description, highlight, type, whitespace = false) {
  * followed by the OPTIONAL scope, OPTIONAL !, and REQUIRED terminal colon and space.
  */
 class CC01 {
-    constructor() {
-        this.id = "CC-01";
-        this.description = "Commits MUST be prefixed with a type, which consists of a noun, feat, fix, etc., followed by the OPTIONAL scope, OPTIONAL !, and REQUIRED terminal colon and space.";
-    }
+    id = "CC-01";
+    description = "Commits MUST be prefixed with a type, which consists of a noun, feat, fix, etc., followed by the OPTIONAL scope, OPTIONAL !, and REQUIRED terminal colon and space.";
     validate(commit, _options) {
         const errors = [];
         // MUST be prefixed with a type
@@ -2693,29 +2791,36 @@ class CC01 {
         else {
             // Ensure that we have a noun
             if (!isNoun(commit.type.value))
-                errors.push(createError(commit, this.description, "which consists of a noun", "type"));
+                errors.push(createDiagnosticsMessage(commit, this.description, "which consists of a noun", "type"));
             // Validate for spacing after the type
             if (commit.type.value.trim() !== commit.type.value) {
-                if (commit.scope.value)
-                    errors.push(createError(commit, this.description, "followed by the OPTIONAL scope", "scope", true));
-                else if (commit.breaking.value)
-                    errors.push(createError(commit, this.description, ["followed by the", "OPTIONAL !"], "breaking", true));
-                else
-                    errors.push(createError(commit, this.description, ["followed by the", "REQUIRED terminal colon"], "seperator", true));
+                if (commit.scope.value) {
+                    errors.push(createDiagnosticsMessage(commit, this.description, "followed by the OPTIONAL scope", "scope", true));
+                }
+                else if (commit.breaking.value) {
+                    errors.push(createDiagnosticsMessage(commit, this.description, ["followed by the", "OPTIONAL !"], "breaking", true));
+                }
+                else {
+                    errors.push(createDiagnosticsMessage(commit, this.description, ["followed by the", "REQUIRED terminal colon"], "seperator", true));
+                }
             }
             // Validate for spacing after the scope, breaking and seperator
             if (commit.scope.value && commit.scope.value.trim() !== commit.scope.value) {
-                if (commit.breaking.value)
-                    errors.push(createError(commit, this.description, ["followed by the", "OPTIONAL !"], "breaking", true));
-                else
-                    errors.push(createError(commit, this.description, ["followed by the", "REQUIRED terminal colon"], "seperator", true));
+                if (commit.breaking.value) {
+                    errors.push(createDiagnosticsMessage(commit, this.description, ["followed by the", "OPTIONAL !"], "breaking", true));
+                }
+                else {
+                    errors.push(createDiagnosticsMessage(commit, this.description, ["followed by the", "REQUIRED terminal colon"], "seperator", true));
+                }
             }
-            if (commit.breaking.value && commit.breaking.value.trim() !== commit.breaking.value)
-                errors.push(createError(commit, this.description, ["followed by the", "REQUIRED terminal colon"], "seperator", true));
+            if (commit.breaking.value && commit.breaking.value.trim() !== commit.breaking.value) {
+                errors.push(createDiagnosticsMessage(commit, this.description, ["followed by the", "REQUIRED terminal colon"], "seperator", true));
+            }
         }
         // MUST have a terminal colon
-        if (!commit.seperator.value)
-            errors.push(createError(commit, this.description, ["followed by the", "REQUIRED terminal colon"], "seperator"));
+        if (!commit.seperator.value) {
+            errors.push(createDiagnosticsMessage(commit, this.description, ["followed by the", "REQUIRED terminal colon"], "seperator"));
+        }
         return errors;
     }
 }
@@ -2724,16 +2829,14 @@ class CC01 {
  * a section of the codebase surrounded by parenthesis, e.g., fix(parser):
  */
 class CC04 {
-    constructor() {
-        this.id = "CC-04";
-        this.description = "A scope MAY be provided after a type. A scope MUST consist of a noun describing a section of the codebase surrounded by parenthesis, e.g., fix(parser):";
-    }
+    id = "CC-04";
+    description = "A scope MAY be provided after a type. A scope MUST consist of a noun describing a section of the codebase surrounded by parenthesis, e.g., fix(parser):";
     validate(commit, _options) {
         const errors = [];
         if (commit.scope.value &&
             (commit.scope.value === "()" ||
                 !isNoun(commit.scope.value.trimEnd().substring(1, commit.scope.value.trimEnd().length - 1)))) {
-            errors.push(createError(commit, this.description, "A scope MUST consist of a noun", "scope"));
+            errors.push(createDiagnosticsMessage(commit, this.description, "A scope MUST consist of a noun", "scope"));
         }
         return errors;
     }
@@ -2744,17 +2847,73 @@ class CC04 {
  * when multiple spaces were contained in string.
  */
 class CC05 {
-    constructor() {
-        this.id = "CC-05";
-        this.description = "A description MUST immediately follow the colon and space after the type/scope prefix. The description is a short summary of the code changes, e.g., fix: array parsing issue when multiple spaces were contained in string.";
-    }
+    id = "CC-05";
+    description = "A description MUST immediately follow the colon and space after the type/scope prefix. The description is a short summary of the code changes, e.g., fix: array parsing issue when multiple spaces were contained in string.";
     validate(commit, _options) {
         const errors = [];
-        if (!commit.seperator.value)
+        if (!commit.seperator.value) {
             return errors;
+        }
         if (commit.description.value === undefined ||
-            commit.seperator.value.length - commit.seperator.value.trim().length !== 1)
-            errors.push(createError(commit, this.description, "A description MUST immediately follow the colon and space", "description", true));
+            commit.seperator.value.length - commit.seperator.value.trim().length !== 1) {
+            errors.push(createDiagnosticsMessage(commit, this.description, "A description MUST immediately follow the colon and space", "description", true));
+        }
+        return errors;
+    }
+}
+/**
+ * A longer commit body MAY be provided after the short description, providing
+ * additional contextual information about the code changes. The body MUST begin one
+ * blank line after the description.
+ */
+class CC06 {
+    id = "CC-06";
+    description = "A longer commit body MAY be provided after the short description, providing additional contextual information about the code changes. The body MUST begin one blank line after the description.";
+    validate(commit, _options) {
+        const errors = [];
+        if (!commit.commit.subject) {
+            return errors;
+        }
+        const lines = commit.commit.subject.split(/\r?\n/);
+        if (lines.length > 1) {
+            return [
+                diagnose_it_1.DiagnosticsMessage.createError(commit.commit.hash, {
+                    text: highlightString(this.description, "The body MUST begin one blank line after the description"),
+                    linenumber: 2,
+                    column: 1,
+                })
+                    .setContext(1, lines)
+                    .addFixitHint(diagnose_it_1.FixItHint.createRemoval({ index: 1, length: lines[1].length })),
+            ];
+        }
+        return errors;
+    }
+}
+/**
+ * The units of information that make up Conventional Commits MUST NOT be treated as case
+ * sensitive by implementors, with the exception of BREAKING CHANGE which MUST be uppercase.
+ */
+class CC15 {
+    id = "CC-15";
+    description = "The units of information that make up Conventional Commits MUST NOT be treated as case sensitive by implementors, with the exception of BREAKING CHANGE which MUST be uppercase.";
+    validate(commit, _options) {
+        const errors = [];
+        const footerElements = (0, commit_1.getFooterElementsFromParagraph)(commit.commit.raw);
+        if (footerElements === undefined)
+            return errors;
+        for (const element of footerElements) {
+            if (["BREAKING CHANGE", "BREAKING-CHANGE"].includes(element.key.toUpperCase())) {
+                if (element.key !== element.key.toUpperCase()) {
+                    errors.push(diagnose_it_1.DiagnosticsMessage.createError(commit.commit.hash, {
+                        text: highlightString(this.description, "BREAKING CHANGE MUST be uppercase"),
+                        linenumber: element.lineNumber,
+                        column: 1,
+                    })
+                        .setContext(element.lineNumber, commit.commit.raw.split(/\r?\n/)[element.lineNumber - 1])
+                        .addFixitHint(diagnose_it_1.FixItHint.create({ index: 1, length: element.key.length })));
+                }
+            }
+        }
         return errors;
     }
 }
@@ -2762,20 +2921,19 @@ class CC05 {
  * A scope MAY be provided after a type. A scope MUST consist of one of the configured values (...) surrounded by parenthesis
  */
 class EC01 {
-    constructor() {
-        this.id = "EC-01";
-        this.description = "A scope MAY be provided after a type. A scope MUST consist of one of the configured values (...) surrounded by parenthesis";
-    }
+    id = "EC-01";
+    description = "A scope MAY be provided after a type. A scope MUST consist of one of the configured values (...) surrounded by parenthesis";
     validate(commit, options) {
-        var _a;
-        const uniqueScopeList = Array.from(new Set((_a = options === null || options === void 0 ? void 0 : options.scopes) !== null && _a !== void 0 ? _a : []));
-        if (uniqueScopeList.length === 0)
+        const uniqueScopeList = Array.from(new Set(options?.scopes ?? []));
+        if (uniqueScopeList.length === 0) {
             return [];
-        if (commit.scope.value === undefined || uniqueScopeList.includes(commit.scope.value.replace(/[()]+/g, "")))
+        }
+        if (commit.scope.value === undefined || uniqueScopeList.includes(commit.scope.value.replace(/[()]+/g, ""))) {
             return [];
+        }
         this.description = `A scope MAY be provided after a type. A scope MUST consist of one of the configured values (${uniqueScopeList.join(", ")}) surrounded by parenthesis`;
         return [
-            createError(commit, this.description, ["A scope MUST consist of", `(${uniqueScopeList.join(", ")})`], "scope"),
+            createDiagnosticsMessage(commit, this.description, ["A scope MUST consist of", `(${uniqueScopeList.join(", ")})`], "scope"),
         ];
     }
 }
@@ -2783,33 +2941,74 @@ class EC01 {
  * Commits MUST be prefixed with a type, which consists of one of the configured values (feat, fix, ...)
  */
 class EC02 {
-    constructor() {
-        this.id = "EC-02";
-        this.description = "Commits MUST be prefixed with a type, which consists of one of the configured values (feat, fix, ...)";
-    }
+    id = "EC-02";
+    description = "Commits MUST be prefixed with a type, which consists of one of the configured values (feat, fix, ...)";
     validate(commit, options) {
-        var _a;
-        const uniqueAddedTypes = new Set((_a = options === null || options === void 0 ? void 0 : options.types) !== null && _a !== void 0 ? _a : []);
+        const uniqueAddedTypes = new Set(options?.types ?? []);
         if (uniqueAddedTypes.has("feat"))
             uniqueAddedTypes.delete("feat");
         if (uniqueAddedTypes.has("fix"))
             uniqueAddedTypes.delete("fix");
         const expectedTypes = ["feat", "fix", ...Array.from(uniqueAddedTypes)];
-        this.description = `Commits MUST be prefixed with a type, which consists of one of the configured values (${expectedTypes.join(", ")}).`;
+        this.description = `Commits ${uniqueAddedTypes.size > 0 ? "MUST" : "MAY"} be prefixed with a type, which consists of one of the configured values (${expectedTypes.join(", ")}).`;
         if (commit.type.value === undefined ||
             !isNoun(commit.type.value) ||
-            expectedTypes.includes(commit.type.value.trimEnd()))
+            expectedTypes.includes(commit.type.value.toLowerCase().trimEnd())) {
             return [];
-        if (commit.type.value.trim().length === 0) {
-            return [createError(commit, this.description, "prefixed with a type", "type")];
         }
-        return [
-            createError(commit, this.description, ["prefixed with a type, which consists of", `(${expectedTypes.join(", ")})`], "type"),
-        ];
+        if (commit.type.value.trim().length === 0) {
+            return [createDiagnosticsMessage(commit, this.description, "prefixed with a type", "type")];
+        }
+        if (uniqueAddedTypes.size > 0) {
+            return [
+                createDiagnosticsMessage(commit, this.description, ["prefixed with a type, which consists of", `(${expectedTypes.join(", ")})`], "type"),
+            ];
+        }
+        else {
+            return [
+                createDiagnosticsMessage(commit, this.description, ["prefixed with a type, which consists of", `(${expectedTypes.join(", ")})`], "type", false, diagnose_it_1.DiagnosticsLevelEnum.Warning),
+            ];
+        }
+    }
+}
+/**
+ * A `BREAKING CHANGE` git-trailer has been found in the body of the commit message and will be ignored as it MUST be included in the footer.
+ */
+class WA01 {
+    id = "WA-01";
+    description = "A `BREAKING CHANGE` git-trailer has been found in the body of the commit message and will be ignored as it MUST be included in the footer.";
+    validate(commit, _options) {
+        const errors = [];
+        if (commit.commit.body === undefined)
+            return errors;
+        const elements = (0, commit_1.getFooterElementsFromParagraph)(commit.commit.body);
+        if (elements === undefined)
+            return errors;
+        for (const element of elements) {
+            if (element.key === "BREAKING CHANGE" || element.key === "BREAKING-CHANGE") {
+                errors.push(diagnose_it_1.DiagnosticsMessage.createWarning(commit.commit.hash, {
+                    text: highlightString(`A \`${element.key}\` git-trailer has been found in the body of the commit message and will be ignored as it MUST be included in the footer.`, [element.key, "will be ignored as it MUST be included in the footer"]),
+                    linenumber: commit.commit.subject.split(/\r?\n/).length + element.lineNumber,
+                    column: 1,
+                })
+                    .setContext(commit.commit.subject.split(/\r?\n/).length + 1, commit.commit.body.split(/\r?\n/))
+                    .addFixitHint(diagnose_it_1.FixItHint.create({ index: 1, length: element.key.length })));
+            }
+        }
+        return errors;
     }
 }
 /** @internal */
-exports.commitRules = [new CC01(), new CC04(), new CC05(), new EC01(), new EC02()];
+exports.commitRules = [
+    new CC01(),
+    new CC04(),
+    new CC05(),
+    new CC06(),
+    new CC15(),
+    new EC01(),
+    new EC02(),
+    new WA01(),
+];
 
 
 /***/ }),
@@ -36279,7 +36478,7 @@ async function getChangesSince(ref) {
     })) {
         commits.push(...response.data.commits);
     }
-    return commits.map(c => commit.getCommit({ hash: c.sha, message: c.commit.message }));
+    return commits.map(c => commit.Commit.fromString({ hash: c.sha, message: c.commit.message }));
 }
 exports.getChangesSince = getChangesSince;
 /**
@@ -36295,7 +36494,7 @@ async function getInitialCommit() {
     })) {
         commits.push(...response.data);
     }
-    const commitMap = commits.map(c => commit.getCommit({ hash: c.sha, message: c.commit.message }));
+    const commitMap = commits.map(c => commit.Commit.fromString({ hash: c.sha, message: c.commit.message }));
     return commitMap[commitMap.length - 1];
 }
 exports.getInitialCommit = getInitialCommit;
@@ -36338,7 +36537,6 @@ var __importStar = (this && this.__importStar) || function (mod) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getIncrementType = exports.getVersionScheme = exports.compareVersions = exports.incrementVersion = exports.CalVerScheme = exports.SemVerScheme = exports.VersionScheme = void 0;
 const core = __importStar(__nccwpck_require__(2186));
-const commit_it_1 = __nccwpck_require__(9403);
 const version_it_1 = __nccwpck_require__(4209);
 const branching = __importStar(__nccwpck_require__(8570));
 /**
@@ -36391,14 +36589,14 @@ class SemVerScheme extends VersionScheme {
     determineIncrementType(commits) {
         const typeCount = { feat: 0, fix: 0 };
         for (const commit of commits) {
-            try {
-                if (commit.breaking)
-                    return branching.getBranch().type === "default" ? "MAJOR" : "PATCH";
-                typeCount[commit.type]++;
-            }
-            catch (error) {
-                if (!(error instanceof commit_it_1.ConventionalCommitError))
-                    throw error;
+            if (!commit.isValid)
+                continue;
+            if (commit.breaking)
+                return branching.getBranch().type === "default" ? "MAJOR" : "PATCH";
+            // Implementors of the Conventional Commit specification MUST always treat Conventional Commit elements as non-case sensitive.
+            const commitType = commit.type?.toLowerCase() ?? "";
+            if (commitType === "feat" || commitType === "fix") {
+                typeCount[commitType]++;
             }
         }
         // Release branches always resort to PATCH versions.

--- a/lib/main/index.js
+++ b/lib/main/index.js
@@ -4341,9 +4341,9 @@ function isLoopbackAddress(host) {
 "use strict";
 
 /*
-SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
-SPDX-License-Identifier: MIT
-*/
+ * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
+ */
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     var desc = Object.getOwnPropertyDescriptor(m, k);
@@ -4368,8 +4368,75 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getCommit = exports.isConventionalCommit = exports.parseCommitMessage = void 0;
+exports.parseCommitMessage = exports.getFooterElementsFromParagraph = exports.Commit = void 0;
 const git = __importStar(__nccwpck_require__(8433));
+const TRAILER_REGEX = /^((BREAKING CHANGE:)|([\w-]+(:| #))|([ \t]+)\w*)/i;
+/**
+ * Git Commit
+ * @class Commit
+ * @member author The commit author and date
+ * @member commiter The commit commiter and date
+ * @member hash The commit hash
+ * @member subject The commit subject
+ * @member body The commit body
+ * @member footer The commit footer
+ * @member raw The commit message
+ */
+class Commit {
+    _commit;
+    constructor(commit) {
+        this._commit = commit;
+    }
+    /**
+     * Retrieves the commit information from git using the provided hash
+     * @param props The commit hash and root path
+     * @returns The commit object
+     */
+    static fromHash(props) {
+        const commit = git.getCommitFromHash(props.hash, props.rootPath ?? process.cwd());
+        return new Commit(commit);
+    }
+    /**
+     * Creates a Commit object from the provided string
+     * @param props The commit hash, author, committer and message
+     * @returns The commit object
+     */
+    static fromString(props) {
+        const commit = {
+            hash: props.hash,
+            ...parseCommitMessage(props.message),
+            author: props.author,
+            committer: props.committer,
+            raw: props.message,
+        };
+        return new Commit(commit);
+    }
+    get author() {
+        return this._commit.author;
+    }
+    get committer() {
+        return this._commit.committer;
+    }
+    get hash() {
+        return this._commit.hash;
+    }
+    get subject() {
+        return this._commit.subject;
+    }
+    get body() {
+        return this._commit.body;
+    }
+    get footer() {
+        return this._commit.footer;
+    }
+    get raw() {
+        return this._commit.raw;
+    }
+    toJSON() {
+        return this._commit;
+    }
+}
+exports.Commit = Commit;
 /**
  * Returns a dictionary containing key-value pairs extracted from the footer of the provided commit message.
  * The key must either be:
@@ -4379,13 +4446,15 @@ const git = __importStar(__nccwpck_require__(8433));
  * The value is either:
  * - the remainder of the line
  * - the remainder of the line + anything that follows on the next lines which is indented by at least one space
+ *
+ * @internal
  */
-function parseCommitFooter(footer) {
-    const footerLines = footer.split(/[\r\n]+/);
-    const result = {};
+function getFooterElementsFromParagraph(footer) {
+    const footerLines = footer.split(/\r?\n/);
+    const result = [];
     for (let lineNr = 0; lineNr < footerLines.length; lineNr++) {
         const line = footerLines[lineNr];
-        const match = /^((BREAKING CHANGE:)|([\w-]+(:| #))|([ \t]+)\w)/.exec(line);
+        const match = TRAILER_REGEX.exec(line);
         if (match === null)
             continue;
         let key = match[1].replace(/:$/, "");
@@ -4394,15 +4463,22 @@ function parseCommitFooter(footer) {
             key = match[1].substring(0, match[1].length - 2);
             value = `#${value}`;
         }
+        const matchLine = lineNr;
         // Check if the value continues on the next line
-        while (lineNr + 1 < footerLines.length && footerLines[lineNr + 1].startsWith(" ")) {
+        while (lineNr + 1 < footerLines.length &&
+            (/^\s/.test(footerLines[lineNr + 1]) || footerLines[lineNr + 1].length === 0)) {
             lineNr++;
             value += "\n" + footerLines[lineNr].trim();
         }
-        result[key] = value;
+        result.push({
+            lineNumber: matchLine + 1,
+            key,
+            value,
+        });
     }
     return Object.keys(result).length > 0 ? result : undefined;
 }
+exports.getFooterElementsFromParagraph = getFooterElementsFromParagraph;
 /**
  * Parses the provided commit message (full message, not just the subject) into
  * a Commit object.
@@ -4411,11 +4487,11 @@ function parseCommitFooter(footer) {
  * @internal
  */
 function parseCommitMessage(message) {
-    const isTrailerOnly = (message) => message.split(/[\r\n]+/).every(line => {
-        const match = /^((BREAKING CHANGE:)|([\w-]+(:| #))|([ \t]+)\w)/.exec(line);
+    const isTrailerOnly = (message) => message.split(/\r?\n/).every(line => {
+        const match = TRAILER_REGEX.exec(line);
         return match !== null;
     });
-    const paragraphs = message.split(/^[\r\n]+/m);
+    const paragraphs = message.split(/^\r?\n/m);
     let footer = undefined;
     let body = undefined;
     if (paragraphs.length > 1 && isTrailerOnly(paragraphs[paragraphs.length - 1])) {
@@ -4430,69 +4506,26 @@ function parseCommitMessage(message) {
     return {
         subject: paragraphs[0].trim(),
         body: body,
-        footer: parseCommitFooter(footer !== null && footer !== void 0 ? footer : ""),
+        footer: getFooterElementsFromParagraph(footer ?? "")?.reduce((acc, cur) => {
+            acc[cur.key] = cur.value;
+            return acc;
+        }, {}),
     };
 }
 exports.parseCommitMessage = parseCommitMessage;
-/**
- * Confirms whether the provided commit is a Conventional Commit
- * @param commit
- * @returns
- */
-function isConventionalCommit(commit) {
-    return "type" in commit;
-}
-exports.isConventionalCommit = isConventionalCommit;
-/**
- * Retrieves the commit message (from the indicated source) given the provided SHA hash
- * @param hash SHA of the commit
- * @param source The data source to retrieve the commit message from (git or github)
- * @param options The options to use when retrieving the commit message
- * @returns Commit object
- */
-function getCommit(options) {
-    var _a;
-    let commit;
-    // String data source
-    if ("message" in options) {
-        const stringOptions = options;
-        commit = {
-            hash: stringOptions.hash,
-            ...parseCommitMessage(stringOptions.message),
-            author: stringOptions.author,
-            committer: stringOptions.committer,
-        };
-        // GitHub data source
-    }
-    else if ("owner" in options) {
-        const githubOptions = options;
-        // TODO; implement basic GitHub client
-        commit = {
-            hash: githubOptions.hash,
-            subject: "",
-        };
-        // Git data source
-    }
-    else {
-        const gitOptions = options;
-        commit = git.getCommitFromHash(gitOptions.hash, (_a = gitOptions.rootPath) !== null && _a !== void 0 ? _a : process.cwd());
-    }
-    return commit;
-}
-exports.getCommit = getCommit;
 
 
 /***/ }),
 
-/***/ 8436:
+/***/ 1124:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
 
 /*
-SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
-SPDX-License-Identifier: MIT
-*/
+ * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
+ */
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     var desc = Object.getOwnPropertyDescriptor(m, k);
@@ -4516,101 +4549,166 @@ var __importStar = (this && this.__importStar) || function (mod) {
     __setModuleDefault(result, mod);
     return result;
 };
-var __importDefault = (this && this.__importDefault) || function (mod) {
-    return (mod && mod.__esModule) ? mod : { "default": mod };
-};
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.getConventionalCommit = exports.isConventionalCommit = exports.ConventionalCommitError = void 0;
-const assert_1 = __importDefault(__nccwpck_require__(9491));
+exports.ConventionalCommit = void 0;
+const diagnose_it_1 = __nccwpck_require__(4657);
+const commit_1 = __nccwpck_require__(8065);
 const requirements = __importStar(__nccwpck_require__(4374));
 /**
- * Conventional Commit error
- * @class ConventionalCommitError
- * @extends Error
+ * Conventional Commit
+ * @class ConventionalCommit
+ * @member type Conventional Commit type
+ * @member scope Conventional Commit scope
+ * @member breaking Commit message has a Conventional Commit breaking change (!)
+ * @member description Conventional Commit description
+ * @member hash Commit hash
+ * @member subject Commit subject
+ * @member body Commit body
+ * @member footer Commit footer
+ * @member author Commit author and date
+ * @member committer Commit committer and date
+ * @member isValid Whether the Conventional Commit is valid
  * @member errors List of error messages
+ * @member warnings List of warning messages
  */
-class ConventionalCommitError extends Error {
-    constructor(errors) {
-        super("Commit is not compliant with the Conventional Commits specification.");
-        this.name = "ConventionalCommitError";
-        this.errors = errors;
+class ConventionalCommit {
+    _raw;
+    _errors = [];
+    _warnings = [];
+    constructor(raw, options) {
+        this._raw = raw;
+        this.validate(options);
+    }
+    /**
+     * Creates a new Conventional Commit object from the provided Commit.
+     * @param commit Commit to convert to a Conventional Commit
+     * @param options Options to use when validating the commit message
+     * @returns Conventional Commit
+     */
+    static fromCommit(commit, options) {
+        // Convert the Commit message to Raw Conventional Commit data
+        const rawConvCommit = createRawConventionalCommit(commit);
+        // Create a new Conventional Commit object
+        return new ConventionalCommit(rawConvCommit, options);
+    }
+    /**
+     * Creates a new Conventional Commit object from the provided string.
+     * @param props Hash, message and author/committer information
+     * @param options Options to use when validating the commit message
+     * @returns Conventional Commit
+     */
+    static fromString(props, options) {
+        return ConventionalCommit.fromCommit(commit_1.Commit.fromString(props), options);
+    }
+    /**
+     * Creates a new Conventional Commit object from the provided hash.
+     * @param props Hash and root path
+     * @param options Options to use when validating the commit message
+     * @returns Conventional Commit
+     */
+    static fromHash(props, options) {
+        return ConventionalCommit.fromCommit(commit_1.Commit.fromHash(props), options);
+    }
+    // Contributors
+    get author() {
+        return this._raw.commit.author;
+    }
+    get committer() {
+        return this._raw.commit.committer;
+    }
+    // Commit
+    get hash() {
+        return this._raw.commit.hash;
+    }
+    get subject() {
+        return this._raw.commit.subject;
+    }
+    get body() {
+        return this._raw.commit.body;
+    }
+    get footer() {
+        return this._raw.commit.footer;
+    }
+    // Conventional Commit
+    get type() {
+        return this._raw.type.value?.trimEnd();
+    }
+    get scope() {
+        // Removes the parenthesis from the scope
+        if (this._raw.scope.value !== undefined) {
+            return this._raw.scope.value.trimEnd().replace(/(\(|\))/g, "");
+        }
+        return this._raw.scope.value;
+    }
+    get description() {
+        return this._raw.description.value;
+    }
+    get breaking() {
+        return (this._raw.breaking.value?.trimEnd() === "!" ||
+            (this.footer !== undefined && ("BREAKING CHANGE" in this.footer || "BREAKING-CHANGE" in this.footer)));
+    }
+    // Raw
+    get raw() {
+        return this._raw.commit.raw;
+    }
+    // Validation
+    get isValid() {
+        return this._errors.length === 0;
+    }
+    get warnings() {
+        return this._warnings;
+    }
+    get errors() {
+        return this._errors;
+    }
+    toJSON() {
+        return {
+            hash: this.hash,
+            author: this.author,
+            committer: this.committer,
+            subject: this.subject,
+            body: this.body,
+            footer: this.footer,
+            type: this.type,
+            breaking: this.breaking,
+            description: this.description,
+            validation: {
+                isValid: this.isValid,
+                errors: this.errors,
+                warnings: this.warnings,
+            },
+        };
+    }
+    // Private validation function
+    validate(options) {
+        let results = [];
+        requirements.commitRules.forEach(rule => (results = [...results, ...rule.validate(this._raw, options)]));
+        this._errors = results.filter(r => r.level === diagnose_it_1.DiagnosticsLevelEnum.Error);
+        this._warnings = results.filter(r => r.level === diagnose_it_1.DiagnosticsLevelEnum.Warning);
     }
 }
-exports.ConventionalCommitError = ConventionalCommitError;
-/**
- * Returns whether the provided commit has a breaking change (either "!" in subject, or usage of /BREAKING[- ]CHANGE:/).
- * @param commit Commit to check
- * @returns Whether the provided commit has a breaking change
- */
-function hasBreakingChange(commit) {
-    return (commit.breaking.value === "!" ||
-        (commit.commit.footer !== undefined &&
-            ("BREAKING CHANGE" in commit.commit.footer || "BREAKING-CHANGE" in commit.commit.footer)));
-}
-/**
- * Validates a commit message against the Conventional Commit specification.
- * @param commit Commit message to validate against the Conventional Commit specification
- * @returns Conventional Commit mesage
- * @throws ExpressiveMessage[] if the commit message is not a valid Conventional Commit
- * @see https://www.conventionalcommits.org/en/v1.0.0/
- */
-function validate(commit, options) {
-    let errors = [];
-    requirements.commitRules.forEach(rule => (errors = [...errors, ...rule.validate(commit, options)]));
-    if (errors.length > 0)
-        throw new ConventionalCommitError(errors);
-    // Assume that we have a valid Conventional Commit message
-    (0, assert_1.default)(commit.type.value);
-    (0, assert_1.default)(commit.description.value);
-    return {
-        ...commit.commit,
-        type: commit.type.value,
-        scope: commit.scope.value,
-        breaking: hasBreakingChange(commit),
-        description: commit.description.value,
-    };
-}
-/**
- * Returns whether the provided commit is a Conventional Commit.
- * @param commit Commit to check
- * @returns Whether the provided commit is a Conventional Commit
- */
-function isConventionalCommit(commit) {
-    return "type" in commit;
-}
-exports.isConventionalCommit = isConventionalCommit;
-/**
- * Parses a Commit message into a Conventional Commit.
- * @param commit Commit message to parse
- * @param options Options to use when parsing the commit message
- * @throws ExpressiveMessage[] if the commit message is not a valid Conventional Commit
- * @returns Conventional Commit
- */
-function getConventionalCommit(commit, options) {
-    var _a, _b, _c, _d, _e;
+exports.ConventionalCommit = ConventionalCommit;
+function createRawConventionalCommit(commit) {
     const ConventionalCommitRegex = new RegExp(/^(?<type>[^(!:]*)(?<scope>\([^)]*\)\s*)?(?<breaking>!\s*)?(?<separator>:\s*)?(?<subject>.*)?$/);
-    const match = ConventionalCommitRegex.exec(commit.subject);
-    let conventionalCommit = {
+    const match = ConventionalCommitRegex.exec(commit.subject.split(/\r?\n/)[0]);
+    const conventionalCommit = {
         commit: commit,
-        type: { index: 1, value: (_a = match === null || match === void 0 ? void 0 : match.groups) === null || _a === void 0 ? void 0 : _a.type },
-        scope: { index: 1, value: (_b = match === null || match === void 0 ? void 0 : match.groups) === null || _b === void 0 ? void 0 : _b.scope },
-        breaking: { index: 1, value: (_c = match === null || match === void 0 ? void 0 : match.groups) === null || _c === void 0 ? void 0 : _c.breaking },
-        seperator: { index: 1, value: (_d = match === null || match === void 0 ? void 0 : match.groups) === null || _d === void 0 ? void 0 : _d.separator },
-        description: { index: 1, value: (_e = match === null || match === void 0 ? void 0 : match.groups) === null || _e === void 0 ? void 0 : _e.subject },
+        type: { index: 1, value: match?.groups?.type },
+        scope: { index: 1, value: match?.groups?.scope },
+        breaking: { index: 1, value: match?.groups?.breaking },
+        seperator: { index: 1, value: match?.groups?.separator },
+        description: { index: 1, value: match?.groups?.subject },
         body: { index: 1, value: commit.body },
     };
     function intializeIndices(commit) {
-        var _a, _b, _c, _d, _e, _f, _g, _h;
-        commit.scope.index = commit.type.index + ((_b = (_a = commit.type.value) === null || _a === void 0 ? void 0 : _a.length) !== null && _b !== void 0 ? _b : 0);
-        commit.breaking.index = commit.scope.index + ((_d = (_c = commit.scope.value) === null || _c === void 0 ? void 0 : _c.length) !== null && _d !== void 0 ? _d : 0);
-        commit.seperator.index = commit.breaking.index + ((_f = (_e = commit.breaking.value) === null || _e === void 0 ? void 0 : _e.length) !== null && _f !== void 0 ? _f : 0);
-        commit.description.index = commit.seperator.index + ((_h = (_g = commit.seperator.value) === null || _g === void 0 ? void 0 : _g.length) !== null && _h !== void 0 ? _h : 0);
+        commit.scope.index = commit.type.index + (commit.type.value?.length ?? 0);
+        commit.breaking.index = commit.scope.index + (commit.scope.value?.length ?? 0);
+        commit.seperator.index = commit.breaking.index + (commit.breaking.value?.length ?? 0);
+        commit.description.index = commit.seperator.index + (commit.seperator.value?.length ?? 0);
         return commit;
     }
-    conventionalCommit = intializeIndices(conventionalCommit);
-    return validate(conventionalCommit, options);
+    return intializeIndices(conventionalCommit);
 }
-exports.getConventionalCommit = getConventionalCommit;
 
 
 /***/ }),
@@ -4621,9 +4719,9 @@ exports.getConventionalCommit = getConventionalCommit;
 "use strict";
 
 /*
-SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
-SPDX-License-Identifier: MIT
-*/
+ * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
+ */
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     var desc = Object.getOwnPropertyDescriptor(m, k);
@@ -4703,15 +4801,17 @@ function getValueFromKey(commit, key) {
 function parseCommitMessage(commit, hash) {
     const author = extractNameAndDate(getValueFromKey(commit, "author"));
     const committer = extractNameAndDate(getValueFromKey(commit, "committer"));
+    const raw = commit
+        .split(/^[\r\n]+/m)
+        .splice(1)
+        .join("\n")
+        .trim();
     return {
+        raw,
         hash: hash,
         author: author,
         committer: committer,
-        ...ccommit.parseCommitMessage(commit
-            .split(/^[\r\n]+/m)
-            .splice(1)
-            .join("\n")
-            .trim()),
+        ...ccommit.parseCommitMessage(raw),
     };
 }
 /**
@@ -4853,17 +4953,15 @@ function readPackFile(path, index) {
 "use strict";
 
 /*
-SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
-SPDX-License-Identifier: MIT
-*/
+ * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+ * SPDX-License-Identifier: MIT
+ */
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.ConventionalCommitError = exports.isConventionalCommit = exports.getConventionalCommit = exports.getCommit = void 0;
+exports.ConventionalCommit = exports.Commit = void 0;
 var commit_1 = __nccwpck_require__(8065);
-Object.defineProperty(exports, "getCommit", ({ enumerable: true, get: function () { return commit_1.getCommit; } }));
-var conventional_commit_1 = __nccwpck_require__(8436);
-Object.defineProperty(exports, "getConventionalCommit", ({ enumerable: true, get: function () { return conventional_commit_1.getConventionalCommit; } }));
-Object.defineProperty(exports, "isConventionalCommit", ({ enumerable: true, get: function () { return conventional_commit_1.isConventionalCommit; } }));
-Object.defineProperty(exports, "ConventionalCommitError", ({ enumerable: true, get: function () { return conventional_commit_1.ConventionalCommitError; } }));
+Object.defineProperty(exports, "Commit", ({ enumerable: true, get: function () { return commit_1.Commit; } }));
+var conventionalCommit_1 = __nccwpck_require__(1124);
+Object.defineProperty(exports, "ConventionalCommit", ({ enumerable: true, get: function () { return conventionalCommit_1.ConventionalCommit; } }));
 
 
 /***/ }),
@@ -4879,13 +4977,14 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.commitRules = void 0;
 /*
-SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
-
-SPDX-License-Identifier: MIT
-SPDX-License-Identifier: CC-BY-3.0
-*/
+ * SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
+ *
+ * SPDX-License-Identifier: MIT
+ * SPDX-License-Identifier: CC-BY-3.0
+ */
 const diagnose_it_1 = __nccwpck_require__(4657);
 const chalk_1 = __importDefault(__nccwpck_require__(8818));
+const commit_1 = __nccwpck_require__(8065);
 function isNoun(str) {
     return !str.trim().includes(" ") && !/[^a-z]/i.test(str.trim());
 }
@@ -4898,29 +4997,30 @@ function highlightString(str, substring) {
     substring.forEach(sub => (result = result.replace(sub, `${chalk_1.default.cyan(sub)}`)));
     return result;
 }
-function createError(commit, description, highlight, type, whitespace = false) {
-    var _a, _b, _c, _d, _e, _f, _g, _h, _j;
+function createDiagnosticsMessage(commit, description, highlight, type, whitespace = false, level = diagnose_it_1.DiagnosticsLevelEnum.Error) {
     const element = commit[type];
     let hintIndex = element.index;
-    let hintLength = (_b = (_a = element.value) === null || _a === void 0 ? void 0 : _a.trimEnd().length) !== null && _b !== void 0 ? _b : 1;
+    let hintLength = element.value?.trimEnd().length ?? 1;
     if (whitespace) {
         let prevElement = undefined;
         for (const [_key, value] of Object.entries(commit)) {
-            if (value.index > ((_c = prevElement === null || prevElement === void 0 ? void 0 : prevElement.index) !== null && _c !== void 0 ? _c : 0) && value.index < element.index) {
+            if (value.index > (prevElement?.index ?? 0) && value.index < element.index) {
                 prevElement = value;
             }
         }
-        hintIndex = prevElement ? prevElement.index + ((_e = (_d = prevElement.value) === null || _d === void 0 ? void 0 : _d.trimEnd().length) !== null && _e !== void 0 ? _e : 1) : 1;
-        hintLength = ((_g = (_f = prevElement === null || prevElement === void 0 ? void 0 : prevElement.value) === null || _f === void 0 ? void 0 : _f.length) !== null && _g !== void 0 ? _g : 1) - ((_j = (_h = prevElement === null || prevElement === void 0 ? void 0 : prevElement.value) === null || _h === void 0 ? void 0 : _h.trimEnd().length) !== null && _j !== void 0 ? _j : 1);
+        hintIndex = prevElement ? prevElement.index + (prevElement.value?.trimEnd().length ?? 1) : 1;
+        hintLength = (prevElement?.value?.length ?? 1) - (prevElement?.value?.trimEnd().length ?? 1);
     }
-    return diagnose_it_1.DiagnosticsMessage.createError(commit.commit.hash, {
-        text: highlightString(description, highlight),
-        linenumber: 1,
-        column: hintIndex,
+    return new diagnose_it_1.DiagnosticsMessage({
+        file: commit.commit.hash,
+        level,
+        message: {
+            text: highlightString(description, highlight),
+            linenumber: 1,
+            column: hintIndex,
+        },
     })
-        .setContext(1, commit.commit.body !== undefined && commit.commit.body.split("\n").length >= 1
-        ? [commit.commit.subject, "", ...commit.commit.body.split("\n")]
-        : [commit.commit.subject])
+        .setContext(1, commit.commit.subject.split(/\r?\n/)[0])
         .addFixitHint(diagnose_it_1.FixItHint.create({ index: hintIndex, length: hintLength === 0 ? 1 : hintLength }));
 }
 /**
@@ -4928,10 +5028,8 @@ function createError(commit, description, highlight, type, whitespace = false) {
  * followed by the OPTIONAL scope, OPTIONAL !, and REQUIRED terminal colon and space.
  */
 class CC01 {
-    constructor() {
-        this.id = "CC-01";
-        this.description = "Commits MUST be prefixed with a type, which consists of a noun, feat, fix, etc., followed by the OPTIONAL scope, OPTIONAL !, and REQUIRED terminal colon and space.";
-    }
+    id = "CC-01";
+    description = "Commits MUST be prefixed with a type, which consists of a noun, feat, fix, etc., followed by the OPTIONAL scope, OPTIONAL !, and REQUIRED terminal colon and space.";
     validate(commit, _options) {
         const errors = [];
         // MUST be prefixed with a type
@@ -4941,29 +5039,36 @@ class CC01 {
         else {
             // Ensure that we have a noun
             if (!isNoun(commit.type.value))
-                errors.push(createError(commit, this.description, "which consists of a noun", "type"));
+                errors.push(createDiagnosticsMessage(commit, this.description, "which consists of a noun", "type"));
             // Validate for spacing after the type
             if (commit.type.value.trim() !== commit.type.value) {
-                if (commit.scope.value)
-                    errors.push(createError(commit, this.description, "followed by the OPTIONAL scope", "scope", true));
-                else if (commit.breaking.value)
-                    errors.push(createError(commit, this.description, ["followed by the", "OPTIONAL !"], "breaking", true));
-                else
-                    errors.push(createError(commit, this.description, ["followed by the", "REQUIRED terminal colon"], "seperator", true));
+                if (commit.scope.value) {
+                    errors.push(createDiagnosticsMessage(commit, this.description, "followed by the OPTIONAL scope", "scope", true));
+                }
+                else if (commit.breaking.value) {
+                    errors.push(createDiagnosticsMessage(commit, this.description, ["followed by the", "OPTIONAL !"], "breaking", true));
+                }
+                else {
+                    errors.push(createDiagnosticsMessage(commit, this.description, ["followed by the", "REQUIRED terminal colon"], "seperator", true));
+                }
             }
             // Validate for spacing after the scope, breaking and seperator
             if (commit.scope.value && commit.scope.value.trim() !== commit.scope.value) {
-                if (commit.breaking.value)
-                    errors.push(createError(commit, this.description, ["followed by the", "OPTIONAL !"], "breaking", true));
-                else
-                    errors.push(createError(commit, this.description, ["followed by the", "REQUIRED terminal colon"], "seperator", true));
+                if (commit.breaking.value) {
+                    errors.push(createDiagnosticsMessage(commit, this.description, ["followed by the", "OPTIONAL !"], "breaking", true));
+                }
+                else {
+                    errors.push(createDiagnosticsMessage(commit, this.description, ["followed by the", "REQUIRED terminal colon"], "seperator", true));
+                }
             }
-            if (commit.breaking.value && commit.breaking.value.trim() !== commit.breaking.value)
-                errors.push(createError(commit, this.description, ["followed by the", "REQUIRED terminal colon"], "seperator", true));
+            if (commit.breaking.value && commit.breaking.value.trim() !== commit.breaking.value) {
+                errors.push(createDiagnosticsMessage(commit, this.description, ["followed by the", "REQUIRED terminal colon"], "seperator", true));
+            }
         }
         // MUST have a terminal colon
-        if (!commit.seperator.value)
-            errors.push(createError(commit, this.description, ["followed by the", "REQUIRED terminal colon"], "seperator"));
+        if (!commit.seperator.value) {
+            errors.push(createDiagnosticsMessage(commit, this.description, ["followed by the", "REQUIRED terminal colon"], "seperator"));
+        }
         return errors;
     }
 }
@@ -4972,16 +5077,14 @@ class CC01 {
  * a section of the codebase surrounded by parenthesis, e.g., fix(parser):
  */
 class CC04 {
-    constructor() {
-        this.id = "CC-04";
-        this.description = "A scope MAY be provided after a type. A scope MUST consist of a noun describing a section of the codebase surrounded by parenthesis, e.g., fix(parser):";
-    }
+    id = "CC-04";
+    description = "A scope MAY be provided after a type. A scope MUST consist of a noun describing a section of the codebase surrounded by parenthesis, e.g., fix(parser):";
     validate(commit, _options) {
         const errors = [];
         if (commit.scope.value &&
             (commit.scope.value === "()" ||
                 !isNoun(commit.scope.value.trimEnd().substring(1, commit.scope.value.trimEnd().length - 1)))) {
-            errors.push(createError(commit, this.description, "A scope MUST consist of a noun", "scope"));
+            errors.push(createDiagnosticsMessage(commit, this.description, "A scope MUST consist of a noun", "scope"));
         }
         return errors;
     }
@@ -4992,17 +5095,73 @@ class CC04 {
  * when multiple spaces were contained in string.
  */
 class CC05 {
-    constructor() {
-        this.id = "CC-05";
-        this.description = "A description MUST immediately follow the colon and space after the type/scope prefix. The description is a short summary of the code changes, e.g., fix: array parsing issue when multiple spaces were contained in string.";
-    }
+    id = "CC-05";
+    description = "A description MUST immediately follow the colon and space after the type/scope prefix. The description is a short summary of the code changes, e.g., fix: array parsing issue when multiple spaces were contained in string.";
     validate(commit, _options) {
         const errors = [];
-        if (!commit.seperator.value)
+        if (!commit.seperator.value) {
             return errors;
+        }
         if (commit.description.value === undefined ||
-            commit.seperator.value.length - commit.seperator.value.trim().length !== 1)
-            errors.push(createError(commit, this.description, "A description MUST immediately follow the colon and space", "description", true));
+            commit.seperator.value.length - commit.seperator.value.trim().length !== 1) {
+            errors.push(createDiagnosticsMessage(commit, this.description, "A description MUST immediately follow the colon and space", "description", true));
+        }
+        return errors;
+    }
+}
+/**
+ * A longer commit body MAY be provided after the short description, providing
+ * additional contextual information about the code changes. The body MUST begin one
+ * blank line after the description.
+ */
+class CC06 {
+    id = "CC-06";
+    description = "A longer commit body MAY be provided after the short description, providing additional contextual information about the code changes. The body MUST begin one blank line after the description.";
+    validate(commit, _options) {
+        const errors = [];
+        if (!commit.commit.subject) {
+            return errors;
+        }
+        const lines = commit.commit.subject.split(/\r?\n/);
+        if (lines.length > 1) {
+            return [
+                diagnose_it_1.DiagnosticsMessage.createError(commit.commit.hash, {
+                    text: highlightString(this.description, "The body MUST begin one blank line after the description"),
+                    linenumber: 2,
+                    column: 1,
+                })
+                    .setContext(1, lines)
+                    .addFixitHint(diagnose_it_1.FixItHint.createRemoval({ index: 1, length: lines[1].length })),
+            ];
+        }
+        return errors;
+    }
+}
+/**
+ * The units of information that make up Conventional Commits MUST NOT be treated as case
+ * sensitive by implementors, with the exception of BREAKING CHANGE which MUST be uppercase.
+ */
+class CC15 {
+    id = "CC-15";
+    description = "The units of information that make up Conventional Commits MUST NOT be treated as case sensitive by implementors, with the exception of BREAKING CHANGE which MUST be uppercase.";
+    validate(commit, _options) {
+        const errors = [];
+        const footerElements = (0, commit_1.getFooterElementsFromParagraph)(commit.commit.raw);
+        if (footerElements === undefined)
+            return errors;
+        for (const element of footerElements) {
+            if (["BREAKING CHANGE", "BREAKING-CHANGE"].includes(element.key.toUpperCase())) {
+                if (element.key !== element.key.toUpperCase()) {
+                    errors.push(diagnose_it_1.DiagnosticsMessage.createError(commit.commit.hash, {
+                        text: highlightString(this.description, "BREAKING CHANGE MUST be uppercase"),
+                        linenumber: element.lineNumber,
+                        column: 1,
+                    })
+                        .setContext(element.lineNumber, commit.commit.raw.split(/\r?\n/)[element.lineNumber - 1])
+                        .addFixitHint(diagnose_it_1.FixItHint.create({ index: 1, length: element.key.length })));
+                }
+            }
+        }
         return errors;
     }
 }
@@ -5010,20 +5169,19 @@ class CC05 {
  * A scope MAY be provided after a type. A scope MUST consist of one of the configured values (...) surrounded by parenthesis
  */
 class EC01 {
-    constructor() {
-        this.id = "EC-01";
-        this.description = "A scope MAY be provided after a type. A scope MUST consist of one of the configured values (...) surrounded by parenthesis";
-    }
+    id = "EC-01";
+    description = "A scope MAY be provided after a type. A scope MUST consist of one of the configured values (...) surrounded by parenthesis";
     validate(commit, options) {
-        var _a;
-        const uniqueScopeList = Array.from(new Set((_a = options === null || options === void 0 ? void 0 : options.scopes) !== null && _a !== void 0 ? _a : []));
-        if (uniqueScopeList.length === 0)
+        const uniqueScopeList = Array.from(new Set(options?.scopes ?? []));
+        if (uniqueScopeList.length === 0) {
             return [];
-        if (commit.scope.value === undefined || uniqueScopeList.includes(commit.scope.value.replace(/[()]+/g, "")))
+        }
+        if (commit.scope.value === undefined || uniqueScopeList.includes(commit.scope.value.replace(/[()]+/g, ""))) {
             return [];
+        }
         this.description = `A scope MAY be provided after a type. A scope MUST consist of one of the configured values (${uniqueScopeList.join(", ")}) surrounded by parenthesis`;
         return [
-            createError(commit, this.description, ["A scope MUST consist of", `(${uniqueScopeList.join(", ")})`], "scope"),
+            createDiagnosticsMessage(commit, this.description, ["A scope MUST consist of", `(${uniqueScopeList.join(", ")})`], "scope"),
         ];
     }
 }
@@ -5031,33 +5189,74 @@ class EC01 {
  * Commits MUST be prefixed with a type, which consists of one of the configured values (feat, fix, ...)
  */
 class EC02 {
-    constructor() {
-        this.id = "EC-02";
-        this.description = "Commits MUST be prefixed with a type, which consists of one of the configured values (feat, fix, ...)";
-    }
+    id = "EC-02";
+    description = "Commits MUST be prefixed with a type, which consists of one of the configured values (feat, fix, ...)";
     validate(commit, options) {
-        var _a;
-        const uniqueAddedTypes = new Set((_a = options === null || options === void 0 ? void 0 : options.types) !== null && _a !== void 0 ? _a : []);
+        const uniqueAddedTypes = new Set(options?.types ?? []);
         if (uniqueAddedTypes.has("feat"))
             uniqueAddedTypes.delete("feat");
         if (uniqueAddedTypes.has("fix"))
             uniqueAddedTypes.delete("fix");
         const expectedTypes = ["feat", "fix", ...Array.from(uniqueAddedTypes)];
-        this.description = `Commits MUST be prefixed with a type, which consists of one of the configured values (${expectedTypes.join(", ")}).`;
+        this.description = `Commits ${uniqueAddedTypes.size > 0 ? "MUST" : "MAY"} be prefixed with a type, which consists of one of the configured values (${expectedTypes.join(", ")}).`;
         if (commit.type.value === undefined ||
             !isNoun(commit.type.value) ||
-            expectedTypes.includes(commit.type.value.trimEnd()))
+            expectedTypes.includes(commit.type.value.toLowerCase().trimEnd())) {
             return [];
-        if (commit.type.value.trim().length === 0) {
-            return [createError(commit, this.description, "prefixed with a type", "type")];
         }
-        return [
-            createError(commit, this.description, ["prefixed with a type, which consists of", `(${expectedTypes.join(", ")})`], "type"),
-        ];
+        if (commit.type.value.trim().length === 0) {
+            return [createDiagnosticsMessage(commit, this.description, "prefixed with a type", "type")];
+        }
+        if (uniqueAddedTypes.size > 0) {
+            return [
+                createDiagnosticsMessage(commit, this.description, ["prefixed with a type, which consists of", `(${expectedTypes.join(", ")})`], "type"),
+            ];
+        }
+        else {
+            return [
+                createDiagnosticsMessage(commit, this.description, ["prefixed with a type, which consists of", `(${expectedTypes.join(", ")})`], "type", false, diagnose_it_1.DiagnosticsLevelEnum.Warning),
+            ];
+        }
+    }
+}
+/**
+ * A `BREAKING CHANGE` git-trailer has been found in the body of the commit message and will be ignored as it MUST be included in the footer.
+ */
+class WA01 {
+    id = "WA-01";
+    description = "A `BREAKING CHANGE` git-trailer has been found in the body of the commit message and will be ignored as it MUST be included in the footer.";
+    validate(commit, _options) {
+        const errors = [];
+        if (commit.commit.body === undefined)
+            return errors;
+        const elements = (0, commit_1.getFooterElementsFromParagraph)(commit.commit.body);
+        if (elements === undefined)
+            return errors;
+        for (const element of elements) {
+            if (element.key === "BREAKING CHANGE" || element.key === "BREAKING-CHANGE") {
+                errors.push(diagnose_it_1.DiagnosticsMessage.createWarning(commit.commit.hash, {
+                    text: highlightString(`A \`${element.key}\` git-trailer has been found in the body of the commit message and will be ignored as it MUST be included in the footer.`, [element.key, "will be ignored as it MUST be included in the footer"]),
+                    linenumber: commit.commit.subject.split(/\r?\n/).length + element.lineNumber,
+                    column: 1,
+                })
+                    .setContext(commit.commit.subject.split(/\r?\n/).length + 1, commit.commit.body.split(/\r?\n/))
+                    .addFixitHint(diagnose_it_1.FixItHint.create({ index: 1, length: element.key.length })));
+            }
+        }
+        return errors;
     }
 }
 /** @internal */
-exports.commitRules = [new CC01(), new CC04(), new CC05(), new EC01(), new EC02()];
+exports.commitRules = [
+    new CC01(),
+    new CC04(),
+    new CC05(),
+    new CC06(),
+    new CC15(),
+    new EC01(),
+    new EC02(),
+    new WA01(),
+];
 
 
 /***/ }),
@@ -42805,7 +43004,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.run = exports.filterConventionalCommits = void 0;
 const core = __importStar(__nccwpck_require__(2186));
-const commitLib = __importStar(__nccwpck_require__(9403));
+const commit_it_1 = __nccwpck_require__(9403);
 const assets = __importStar(__nccwpck_require__(711));
 const branching = __importStar(__nccwpck_require__(8570));
 const changelog = __importStar(__nccwpck_require__(8598));
@@ -42818,18 +43017,7 @@ const versioning = __importStar(__nccwpck_require__(5622));
  * @internal
  */
 function filterConventionalCommits(commits) {
-    return commits
-        .map(c => {
-        try {
-            return commitLib.getConventionalCommit(c);
-        }
-        catch (error) {
-            if (!(error instanceof commitLib.ConventionalCommitError))
-                throw error;
-        }
-        return;
-    })
-        .filter(c => c !== undefined);
+    return commits.map(c => commit_it_1.ConventionalCommit.fromCommit(c)).filter(c => c.isValid);
 }
 exports.filterConventionalCommits = filterConventionalCommits;
 /**
@@ -43277,6 +43465,8 @@ async function generateChangelog(versionScheme, commits) {
     const changelog = `${title}\n\n${config.changelog?.categories
         ?.map(category => {
         const categoryCommits = commits.filter(commit => {
+            if (!commit.isValid)
+                return false;
             const incrementType = versionScheme.determineIncrementType([commit]);
             const hasValidIncrement = (isWildcard(category.increment) || isMatch(category.increment, incrementType)) &&
                 !isMatch(category.exclude?.increment, incrementType) &&
@@ -43291,7 +43481,7 @@ async function generateChangelog(versionScheme, commits) {
         });
         if (categoryCommits.length > 0)
             return `### ${category.title}\n\n${categoryCommits
-                .map(commit => `- ${firstCharToUpperCase(commit.description)}`)
+                .map(commit => `- ${firstCharToUpperCase(commit.description ?? "")}`)
                 .join("\n")}\n\n`;
         return;
     })
@@ -43456,7 +43646,7 @@ async function getChangesSince(ref) {
     })) {
         commits.push(...response.data.commits);
     }
-    return commits.map(c => commit.getCommit({ hash: c.sha, message: c.commit.message }));
+    return commits.map(c => commit.Commit.fromString({ hash: c.sha, message: c.commit.message }));
 }
 exports.getChangesSince = getChangesSince;
 /**
@@ -43472,7 +43662,7 @@ async function getInitialCommit() {
     })) {
         commits.push(...response.data);
     }
-    const commitMap = commits.map(c => commit.getCommit({ hash: c.sha, message: c.commit.message }));
+    const commitMap = commits.map(c => commit.Commit.fromString({ hash: c.sha, message: c.commit.message }));
     return commitMap[commitMap.length - 1];
 }
 exports.getInitialCommit = getInitialCommit;
@@ -43515,7 +43705,6 @@ var __importStar = (this && this.__importStar) || function (mod) {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.getIncrementType = exports.getVersionScheme = exports.compareVersions = exports.incrementVersion = exports.CalVerScheme = exports.SemVerScheme = exports.VersionScheme = void 0;
 const core = __importStar(__nccwpck_require__(2186));
-const commit_it_1 = __nccwpck_require__(9403);
 const version_it_1 = __nccwpck_require__(4209);
 const branching = __importStar(__nccwpck_require__(8570));
 /**
@@ -43568,14 +43757,14 @@ class SemVerScheme extends VersionScheme {
     determineIncrementType(commits) {
         const typeCount = { feat: 0, fix: 0 };
         for (const commit of commits) {
-            try {
-                if (commit.breaking)
-                    return branching.getBranch().type === "default" ? "MAJOR" : "PATCH";
-                typeCount[commit.type]++;
-            }
-            catch (error) {
-                if (!(error instanceof commit_it_1.ConventionalCommitError))
-                    throw error;
+            if (!commit.isValid)
+                continue;
+            if (commit.breaking)
+                return branching.getBranch().type === "default" ? "MAJOR" : "PATCH";
+            // Implementors of the Conventional Commit specification MUST always treat Conventional Commit elements as non-case sensitive.
+            const commitType = commit.type?.toLowerCase() ?? "";
+            if (commitType === "feat" || commitType === "fix") {
+                typeCount[commitType]++;
             }
         }
         // Release branches always resort to PATCH versions.

--- a/package-lock.json
+++ b/package-lock.json
@@ -750,12 +750,15 @@
       "dev": true
     },
     "node_modules/@dev-build-deploy/commit-it": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@dev-build-deploy/commit-it/-/commit-it-1.0.4.tgz",
-      "integrity": "sha512-dT0bfSmDnj2SD4qVedHuwTIozOcKwEOb5RulndCjXUSJ2IazA3U3VJMyqAf0TTY9h7au/HaKjokjMtomNNi+XA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@dev-build-deploy/commit-it/-/commit-it-2.0.3.tgz",
+      "integrity": "sha512-snSsstI8kytKXmEY5MXxj0pYM2t1JD0uf2uOTQSgHg6pKfC1A8YeiCUFPqbNFSeALLI580RZ3FafTTvU+Gyjyw==",
       "dependencies": {
         "@dev-build-deploy/diagnose-it": "^1",
         "chalk": "<5"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@dev-build-deploy/diagnose-it": {
@@ -829,9 +832,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.55.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.55.0.tgz",
-      "integrity": "sha512-qQfo2mxH5yVom1kacMtZZJFVdW+E70mqHMJvVg6WTLo+VBuQJ4TojZlfWBjK0ve5BdEeNAVxOsl/nvNMpJOaJA==",
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.56.0.tgz",
+      "integrity": "sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -1509,9 +1512,9 @@
       }
     },
     "node_modules/@types/babel__generator": {
-      "version": "7.6.7",
-      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.7.tgz",
-      "integrity": "sha512-6Sfsq+EaaLrw4RmdFWE9Onp63TOUue71AWb4Gpa6JxzgTYtimbM086WnYTy2U67AofR++QKCo08ZP6pwx8YFHQ==",
+      "version": "7.6.8",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.8.tgz",
+      "integrity": "sha512-ASsj+tpEDsEiFr1arWrlN6V3mdfjRMZt6LtK/Vp/kreFLnr5QH5+DhvD5nINYZXzwJvXeGq+05iUXcAzVrqWtw==",
       "dev": true,
       "dependencies": {
         "@babel/types": "^7.0.0"
@@ -2605,9 +2608,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.612",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.612.tgz",
-      "integrity": "sha512-dM8BMtXtlH237ecSMnYdYuCkib2QHq0kpWfUnavjdYsyr/6OsAwg5ZGUfnQ9KD1Ga4QgB2sqXlB2NT8zy2GnVg==",
+      "version": "1.4.614",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.614.tgz",
+      "integrity": "sha512-X4ze/9Sc3QWs6h92yerwqv7aB/uU8vCjZcrMjA8N9R1pjMFRe44dLsck5FzLilOYvcXuDn93B+bpGYyufc70gQ==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -2765,15 +2768,15 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.55.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.55.0.tgz",
-      "integrity": "sha512-iyUUAM0PCKj5QpwGfmCAG9XXbZCWsqP/eWAWrG/W0umvjuLRBECwSFdt+rCntju0xEH7teIABPwXpahftIaTdA==",
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.56.0.tgz",
+      "integrity": "sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
         "@eslint/eslintrc": "^2.1.4",
-        "@eslint/js": "8.55.0",
+        "@eslint/js": "8.56.0",
         "@humanwhocodes/config-array": "^0.11.13",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
@@ -2891,9 +2894,9 @@
       }
     },
     "node_modules/eslint-plugin-import": {
-      "version": "2.29.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.29.0.tgz",
-      "integrity": "sha512-QPOO5NO6Odv5lpoTkddtutccQjysJuFxoPS7fAHO+9m9udNHvTCPSAMW9zGAYj8lAIdr40I8yPCdUYrncXtrwg==",
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.29.1.tgz",
+      "integrity": "sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==",
       "dev": true,
       "dependencies": {
         "array-includes": "^3.1.7",
@@ -2912,7 +2915,7 @@
         "object.groupby": "^1.0.1",
         "object.values": "^1.1.7",
         "semver": "^6.3.1",
-        "tsconfig-paths": "^3.14.2"
+        "tsconfig-paths": "^3.15.0"
       },
       "engines": {
         "node": ">=4"
@@ -6255,9 +6258,9 @@
       }
     },
     "node_modules/tsconfig-paths": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
-      "integrity": "sha512-o/9iXgCYc5L/JxCHPe3Hvh8Q/2xm5Z+p18PESBU6Ff33695QnCHBEjcytY2q19ua7Mbl/DavtBOLq+oG0RCL+g==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
+      "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
       "dev": true,
       "dependencies": {
         "@types/json5": "^0.0.29",

--- a/src/action.ts
+++ b/src/action.ts
@@ -4,7 +4,7 @@
  */
 
 import * as core from "@actions/core";
-import * as commitLib from "@dev-build-deploy/commit-it";
+import { Commit, ConventionalCommit } from "@dev-build-deploy/commit-it";
 
 import * as assets from "./assets";
 import * as branching from "./branching";
@@ -18,18 +18,8 @@ import * as versioning from "./versioning";
  * @returns List of Conventional Commits
  * @internal
  */
-export function filterConventionalCommits(commits: commitLib.ICommit[]): commitLib.IConventionalCommit[] {
-  return commits
-    .map(c => {
-      try {
-        return commitLib.getConventionalCommit(c);
-      } catch (error) {
-        if (!(error instanceof commitLib.ConventionalCommitError)) throw error;
-      }
-
-      return;
-    })
-    .filter(c => c !== undefined) as commitLib.IConventionalCommit[];
+export function filterConventionalCommits(commits: Commit[]): ConventionalCommit[] {
+  return commits.map(c => ConventionalCommit.fromCommit(c)).filter(c => c.isValid);
 }
 
 /**
@@ -45,7 +35,7 @@ export async function run(): Promise<void> {
     const versionOverride = core.getInput("version");
 
     let newVersion: versioning.Version;
-    const commits: commitLib.IConventionalCommit[] = [];
+    const commits: ConventionalCommit[] = [];
 
     core.startGroup("🔍 Determining increment type");
     if (versionOverride) {

--- a/src/changelog.ts
+++ b/src/changelog.ts
@@ -7,7 +7,7 @@ import * as fs from "fs";
 
 import * as core from "@actions/core";
 import * as github from "@actions/github";
-import { IConventionalCommit } from "@dev-build-deploy/commit-it";
+import { ConventionalCommit } from "@dev-build-deploy/commit-it";
 import { CalVerIncrement, SemVerIncrement } from "@dev-build-deploy/version-it";
 import YAML from "yaml";
 
@@ -123,7 +123,7 @@ export async function readChangelogFromFile(file: string): Promise<string> {
  * @param commits Conventional Commits part of the Changelog
  * @returns Changelog in Markdown format
  */
-export async function generateChangelog(versionScheme: VersionScheme, commits: IConventionalCommit[]): Promise<string> {
+export async function generateChangelog(versionScheme: VersionScheme, commits: ConventionalCommit[]): Promise<string> {
   core.info("📓 Generating Release Notes...");
 
   const isWildcard = (value?: string[]): boolean => isMatch(value, "*");
@@ -135,6 +135,8 @@ export async function generateChangelog(versionScheme: VersionScheme, commits: I
   const changelog = `${title}\n\n${config.changelog?.categories
     ?.map(category => {
       const categoryCommits = commits.filter(commit => {
+        if (!commit.isValid) return false;
+
         const incrementType = versionScheme.determineIncrementType([commit]);
 
         const hasValidIncrement =
@@ -157,7 +159,7 @@ export async function generateChangelog(versionScheme: VersionScheme, commits: I
 
       if (categoryCommits.length > 0)
         return `### ${category.title}\n\n${categoryCommits
-          .map(commit => `- ${firstCharToUpperCase(commit.description)}`)
+          .map(commit => `- ${firstCharToUpperCase(commit.description ?? "")}`)
           .join("\n")}\n\n`;
 
       return;

--- a/src/releasing.ts
+++ b/src/releasing.ts
@@ -133,7 +133,7 @@ export async function getLatestRelease(
  * @param ref The git ref to compare against
  * @returns List of commits
  */
-export async function getChangesSince(ref: string): Promise<commit.ICommit[]> {
+export async function getChangesSince(ref: string): Promise<commit.Commit[]> {
   const octokit = github.getOctokit(core.getInput("token"));
   const commits: Commit[] = [];
 
@@ -144,14 +144,14 @@ export async function getChangesSince(ref: string): Promise<commit.ICommit[]> {
     commits.push(...response.data.commits);
   }
 
-  return commits.map(c => commit.getCommit({ hash: c.sha, message: c.commit.message }));
+  return commits.map(c => commit.Commit.fromString({ hash: c.sha, message: c.commit.message }));
 }
 
 /**
  * Determines the initial commit in the current branch
  * @returns The initial commit
  */
-export async function getInitialCommit(): Promise<commit.ICommit> {
+export async function getInitialCommit(): Promise<commit.Commit> {
   const octokit = github.getOctokit(core.getInput("token"));
   const commits: Commit[] = [];
 
@@ -162,6 +162,6 @@ export async function getInitialCommit(): Promise<commit.ICommit> {
     commits.push(...response.data);
   }
 
-  const commitMap = commits.map(c => commit.getCommit({ hash: c.sha, message: c.commit.message }));
+  const commitMap = commits.map(c => commit.Commit.fromString({ hash: c.sha, message: c.commit.message }));
   return commitMap[commitMap.length - 1];
 }

--- a/test/action.test.ts
+++ b/test/action.test.ts
@@ -3,41 +3,20 @@ SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
 SPDX-License-Identifier: MIT
 */
 
+import { Commit, ConventionalCommit } from "@dev-build-deploy/commit-it";
+
 import * as action from "../src/action";
 
 describe("Filter Conventional Commits", () => {
   test("Filter out non-conventional commits", () => {
     const conventionals = action.filterConventionalCommits([
-      {
-        hash: "0a0b0c0d",
-        subject: "feat: add new feature",
-      },
-      {
-        hash: "0a0b0c0d",
-        subject: "fix: prevent bug",
-      },
-      {
-        hash: "0a0b0c0d",
-        subject: "Not a conventional commit",
-      },
+      Commit.fromString({ hash: "0a0b0c0d", message: "feat: add new feature" }),
+      Commit.fromString({ hash: "0a0b0c0d", message: "fix: prevent bug" }),
+      Commit.fromString({ hash: "0a0b0c0d", message: "Not a conventional commit" }),
     ]);
-    expect(conventionals).toStrictEqual([
-      {
-        hash: "0a0b0c0d",
-        subject: "feat: add new feature",
-        breaking: false,
-        description: "add new feature",
-        scope: undefined,
-        type: "feat",
-      },
-      {
-        hash: "0a0b0c0d",
-        subject: "fix: prevent bug",
-        breaking: false,
-        description: "prevent bug",
-        scope: undefined,
-        type: "fix",
-      },
+    expect(conventionals).toEqual([
+      ConventionalCommit.fromString({ hash: "0a0b0c0d", message: "feat: add new feature" }),
+      ConventionalCommit.fromString({ hash: "0a0b0c0d", message: "fix: prevent bug" }),
     ]);
   });
 });

--- a/test/changelog.test.ts
+++ b/test/changelog.test.ts
@@ -3,7 +3,7 @@ SPDX-FileCopyrightText: 2023 Kevin de Jong <monkaii@hotmail.com>
 SPDX-License-Identifier: MIT
 */
 
-import { IConventionalCommit } from "@dev-build-deploy/commit-it";
+import { ConventionalCommit } from "@dev-build-deploy/commit-it";
 
 import * as branching from "../src/branching";
 import * as changelog from "../src/changelog";
@@ -11,31 +11,13 @@ import { SemVerScheme } from "../src/versioning";
 
 describe("Generate Changelog", () => {
   const commits = [
-    { hash: "0a0b0c0d", subject: "feat: add new feature", type: "feat", description: "add new feature" },
-    {
-      hash: "0a0b0c0d",
-      subject: "feat!: add new breaking feature",
-      type: "feat",
-      description: "add new breaking feature",
-      breaking: true,
-    },
-    { hash: "0a0b0c0d", subject: "fix: address a bug", type: "fix", description: "address a bug" },
-    {
-      hash: "0a0b0c0d",
-      subject: "fix(core): address failure in core logic",
-      type: "fix",
-      description: "address failure in core logic",
-      scope: "core",
-    },
-    {
-      hash: "0a0b0c0d",
-      subject: "chore!: break the api",
-      type: "chore",
-      description: "break the api",
-      breaking: true,
-    },
-    { hash: "0a0b0c0d", subject: "docs: improve documentation", type: "docs", description: "improve documentation" },
-    { hash: "0a0b0c0d", subject: "perf: improve performance", type: "perf", description: "improve performance" },
+    ConventionalCommit.fromString({ hash: "0a0b0c0d", message: "feat: add a new feature" }),
+    ConventionalCommit.fromString({ hash: "0a0b0c0d", message: "feat!: add new breaking feature" }),
+    ConventionalCommit.fromString({ hash: "0a0b0c0d", message: "fix: address a bug" }),
+    ConventionalCommit.fromString({ hash: "0a0b0c0d", message: "fix(core): address failure in core logic" }),
+    ConventionalCommit.fromString({ hash: "0a0b0c0d", message: "chore!: break the api" }),
+    ConventionalCommit.fromString({ hash: "0a0b0c0d", message: "docs: improve documentation" }),
+    ConventionalCommit.fromString({ hash: "0a0b0c0d", message: "perf: improve performance" }),
   ];
 
   beforeEach(() => {
@@ -204,52 +186,29 @@ describe("Generate Changelog", () => {
       };
     });
 
-    const commits: IConventionalCommit[] = [
-      {
+    const commits: ConventionalCommit[] = [
+      ConventionalCommit.fromString({
         hash: "0a0b0c0d",
-        subject: "feat!: removed `doIt(...)` as this is replaced by `doItBetter(...)`",
-        type: "feat",
-        description: "removed `doIt(...)` as this is replaced by `doItBetter(...)`",
-        breaking: true,
-      },
-      {
+        message: "feat!: removed `doIt(...)` as this is replaced by `doItBetter(...)`",
+      }),
+      ConventionalCommit.fromString({
         hash: "0a0b0c0d",
-        subject: "feat: add support for a Release Notes configuration file",
-        type: "feat",
-        description: "add support for a Release Notes configuration file",
-      },
-      {
+        message: "feat: add support for a Release Notes configuration file",
+      }),
+      ConventionalCommit.fromString({
         hash: "0a0b0c0d",
-        subject: "feat: allow users to specify the Release Notes configuration file location",
-        type: "feat",
-        description: "allow users to specify the Release Notes configuration file location",
-      },
-      {
+        message: "feat: allow users to specify the Release Notes configuration file location",
+      }),
+      ConventionalCommit.fromString({ hash: "0a0b0c0d", message: "fix: hide empty categories from the Release Notes" }),
+      ConventionalCommit.fromString({ hash: "0a0b0c0d", message: "fix(internal): please do not notice me" }),
+      ConventionalCommit.fromString({
         hash: "0a0b0c0d",
-        subject: "fix: hide empty categories from the Release Notes",
-        type: "fix",
-        description: "hide empty categories from the Release Notes",
-      },
-      {
+        message: "docs(api): add basic description on configuration usage",
+      }),
+      ConventionalCommit.fromString({
         hash: "0a0b0c0d",
-        subject: "fix(internal): please do not notice me",
-        type: "fix",
-        scope: "internal",
-        description: "please do not notice me",
-      },
-      {
-        hash: "0a0b0c0d",
-        subject: "docs(api): add basic description on configuration usage",
-        type: "docs",
-        description: "add basic description on configuration usage",
-        scope: "api",
-      },
-      {
-        hash: "0a0b0c0d",
-        subject: "docs: this should not show up in the Release Notes",
-        type: "docs",
-        description: "this should not show up in the Release Notes",
-      },
+        message: "docs: this should not show up in the Release Notes",
+      }),
     ];
 
     const result = await changelog.generateChangelog(new SemVerScheme(), commits);

--- a/test/versioning.test.ts
+++ b/test/versioning.test.ts
@@ -4,7 +4,7 @@ SPDX-License-Identifier: MIT
 */
 
 import * as core from "@actions/core";
-import { IConventionalCommit } from "@dev-build-deploy/commit-it";
+import { ConventionalCommit } from "@dev-build-deploy/commit-it";
 import { SemVer, CalVer } from "@dev-build-deploy/version-it";
 
 import * as branching from "../src/branching";
@@ -100,16 +100,10 @@ describe("Determine bump type (default branch)", () => {
   });
 
   test("Breaking Change (subject)", () => {
-    const commits: IConventionalCommit[] = [
-      { hash: "0a0b0c0d", subject: "feat: add new feature", type: "feat", description: "add new feature" },
-      { hash: "0a0b0c0d", subject: "fix: prevent bug", type: "fix", description: "prevent bug" },
-      {
-        hash: "0a0b0c0d",
-        subject: "chore!: breaking change",
-        type: "chore",
-        description: "breaking change",
-        breaking: true,
-      },
+    const commits: ConventionalCommit[] = [
+      ConventionalCommit.fromString({ hash: "0a0b0c0d", message: "feat: add new feature" }),
+      ConventionalCommit.fromString({ hash: "0a0b0c0d", message: "fix: prevent bug" }),
+      ConventionalCommit.fromString({ hash: "0a0b0c0d", message: "chore!: breaking change" }),
     ];
     const semver = new versioning.SemVerScheme();
     const calver = new versioning.CalVerScheme();
@@ -119,16 +113,13 @@ describe("Determine bump type (default branch)", () => {
   });
 
   test("Breaking Change (footer)", () => {
-    const commits: IConventionalCommit[] = [
-      { hash: "0a0b0c0d", subject: "feat: add new feature", type: "feat", description: "add new feature" },
-      { hash: "0a0b0c0d", subject: "fix: prevent bug", type: "fix", description: "prevent bug" },
-      {
+    const commits: ConventionalCommit[] = [
+      ConventionalCommit.fromString({ hash: "0a0b0c0d", message: "feat: add new feature" }),
+      ConventionalCommit.fromString({ hash: "0a0b0c0d", message: "fix: prevent bug" }),
+      ConventionalCommit.fromString({
         hash: "0a0b0c0d",
-        subject: "chore: breaking change",
-        type: "chore",
-        description: "breaking change",
-        breaking: true,
-      },
+        message: "chore: breaking change\n\nBREAKING-CHANGE: this is a breaking change",
+      }),
     ];
     const semver = new versioning.SemVerScheme();
     const calver = new versioning.CalVerScheme();
@@ -138,16 +129,10 @@ describe("Determine bump type (default branch)", () => {
   });
 
   test("Added Feature", () => {
-    const commits: IConventionalCommit[] = [
-      {
-        hash: "0a0b0c0d",
-        subject: "feat(login): add support google oauth (#12)",
-        type: "feat",
-        scope: "login",
-        description: "add support google oauth (#12)",
-      },
-      { hash: "0a0b0c0d", subject: "fix: prevent bug", type: "fix", description: "prevent bug" },
-      { hash: "0a0b0c0d", subject: "chore: non breaking change", type: "chore", description: "non breaking change" },
+    const commits: ConventionalCommit[] = [
+      ConventionalCommit.fromString({ hash: "0a0b0c0d", message: "feat(login): add support google oauth (#12)" }),
+      ConventionalCommit.fromString({ hash: "0a0b0c0d", message: "fix: prevent bug" }),
+      ConventionalCommit.fromString({ hash: "0a0b0c0d", message: "chore: non breaking change" }),
     ];
     const semver = new versioning.SemVerScheme();
     const calver = new versioning.CalVerScheme();
@@ -157,9 +142,9 @@ describe("Determine bump type (default branch)", () => {
   });
 
   test("Added bug fix", () => {
-    const commits: IConventionalCommit[] = [
-      { hash: "0a0b0c0d", subject: "fix: prevent bug", type: "fix", description: "prevent bug" },
-      { hash: "0a0b0c0d", subject: "chore: non breaking change", type: "chore", description: "non breaking change" },
+    const commits: ConventionalCommit[] = [
+      ConventionalCommit.fromString({ hash: "0a0b0c0d", message: "fix: prevent bug" }),
+      ConventionalCommit.fromString({ hash: "0a0b0c0d", message: "chore: non breaking change" }),
     ];
     const semver = new versioning.SemVerScheme();
     const calver = new versioning.CalVerScheme();
@@ -169,8 +154,8 @@ describe("Determine bump type (default branch)", () => {
   });
 
   test("No change", () => {
-    const commits: IConventionalCommit[] = [
-      { hash: "0a0b0c0d", subject: "chore: non breaking change", type: "chore", description: "non breaking change" },
+    const commits: ConventionalCommit[] = [
+      ConventionalCommit.fromString({ hash: "0a0b0c0d", message: "chore: non breaking change" }),
     ];
     const semver = new versioning.SemVerScheme();
     const calver = new versioning.CalVerScheme();
@@ -188,16 +173,10 @@ describe("Determine bump type (release branch)", () => {
   });
 
   test("Breaking Change (subject)", () => {
-    const commits: IConventionalCommit[] = [
-      { hash: "0a0b0c0d", subject: "feat: add new feature", type: "feat", description: "add new feature" },
-      { hash: "0a0b0c0d", subject: "fix: prevent bug", type: "fix", description: "prevent bug" },
-      {
-        hash: "0a0b0c0d",
-        subject: "chore!: breaking change",
-        type: "chore",
-        description: "breaking change",
-        breaking: true,
-      },
+    const commits: ConventionalCommit[] = [
+      ConventionalCommit.fromString({ hash: "0a0b0c0d", message: "feat: add new feature" }),
+      ConventionalCommit.fromString({ hash: "0a0b0c0d", message: "fix: prevent bug" }),
+      ConventionalCommit.fromString({ hash: "0a0b0c0d", message: "chore!: breaking change" }),
     ];
     const semver = new versioning.SemVerScheme();
     const calver = new versioning.CalVerScheme();
@@ -207,16 +186,13 @@ describe("Determine bump type (release branch)", () => {
   });
 
   test("Breaking Change (footer)", () => {
-    const commits: IConventionalCommit[] = [
-      { hash: "0a0b0c0d", subject: "feat: add new feature", type: "feat", description: "add new feature" },
-      { hash: "0a0b0c0d", subject: "fix: prevent bug", type: "fix", description: "prevent bug" },
-      {
+    const commits: ConventionalCommit[] = [
+      ConventionalCommit.fromString({ hash: "0a0b0c0d", message: "feat: add new feature" }),
+      ConventionalCommit.fromString({ hash: "0a0b0c0d", message: "fix: prevent bug" }),
+      ConventionalCommit.fromString({
         hash: "0a0b0c0d",
-        subject: "chore: breaking change",
-        type: "chore",
-        description: "breaking change",
-        breaking: true,
-      },
+        message: "chore: breaking change\n\nBREAKING-CHANGE: this is a breaking change",
+      }),
     ];
     const semver = new versioning.SemVerScheme();
     const calver = new versioning.CalVerScheme();
@@ -226,16 +202,10 @@ describe("Determine bump type (release branch)", () => {
   });
 
   test("Added Feature", () => {
-    const commits: IConventionalCommit[] = [
-      {
-        hash: "0a0b0c0d",
-        subject: "feat(login): add support google oauth (#12)",
-        type: "feat",
-        scope: "login",
-        description: "add support google oauth (#12)",
-      },
-      { hash: "0a0b0c0d", subject: "fix: prevent bug", type: "fix", description: "prevent bug" },
-      { hash: "0a0b0c0d", subject: "chore: non breaking change", type: "chore", description: "non breaking change" },
+    const commits: ConventionalCommit[] = [
+      ConventionalCommit.fromString({ hash: "0a0b0c0d", message: "feat(login): add support google oauth (#12)" }),
+      ConventionalCommit.fromString({ hash: "0a0b0c0d", message: "fix: prevent bug" }),
+      ConventionalCommit.fromString({ hash: "0a0b0c0d", message: "chore: non breaking change" }),
     ];
     const semver = new versioning.SemVerScheme();
     const calver = new versioning.CalVerScheme();
@@ -245,9 +215,9 @@ describe("Determine bump type (release branch)", () => {
   });
 
   test("Added bug fix", () => {
-    const commits: IConventionalCommit[] = [
-      { hash: "0a0b0c0d", subject: "fix: prevent bug", type: "fix", description: "prevent bug" },
-      { hash: "0a0b0c0d", subject: "chore: non breaking change", type: "chore", description: "non breaking change" },
+    const commits: ConventionalCommit[] = [
+      ConventionalCommit.fromString({ hash: "0a0b0c0d", message: "fix: prevent bug" }),
+      ConventionalCommit.fromString({ hash: "0a0b0c0d", message: "chore: non breaking change" }),
     ];
     const semver = new versioning.SemVerScheme();
     const calver = new versioning.CalVerScheme();
@@ -257,8 +227,8 @@ describe("Determine bump type (release branch)", () => {
   });
 
   test("No change", () => {
-    const commits: IConventionalCommit[] = [
-      { hash: "0a0b0c0d", subject: "chore: non breaking change", type: "chore", description: "non breaking change" },
+    const commits: ConventionalCommit[] = [
+      ConventionalCommit.fromString({ hash: "0a0b0c0d", message: "chore: non breaking change" }),
     ];
     const semver = new versioning.SemVerScheme();
     const calver = new versioning.CalVerScheme();


### PR DESCRIPTION
This new version of `commit-it` provides a new API and several improvements to Conventional Commit validation. The main changes (in term of compliance) are:

- The `BREAKING[- ]CHANGE` footer element MUST be in capital letters
- Any other Conventional Commit element is to be considered as case insensitive